### PR TITLE
Cleaned up scripts

### DIFF
--- a/examples/snap/README.md
+++ b/examples/snap/README.md
@@ -1,0 +1,7 @@
+# Example fit to surrogate GaN data
+
+To run:
+
+    julia fit_snap_example.jl
+
+Note that `GaN.snapcoeff` and `GaN.snapparam` are not needed for this, but we'll keep them here to show how the SNAP files will be used in LAMMPS for MD.

--- a/examples/snap/fit_snap_example.jl
+++ b/examples/snap/fit_snap_example.jl
@@ -15,7 +15,6 @@ const N2 = 96
 const N = N1 + N2
 const M1 = 48
 const M2 = 61
-const rcut = 3.5
 
 # Calculate b ##################################################################
 
@@ -103,26 +102,30 @@ function calc_fitted_tot_energy(path, β, ncoeff, N1, N)
     ## Calculate b
     lmp = LMP(["-screen","none"]) 
     read_data_str = string("read_data ", path)
+
+    command(lmp, "log none")
     command(lmp, "units metal")
     command(lmp, "boundary p p p")
     command(lmp, "atom_style atomic")
     command(lmp, "atom_modify map array")
     command(lmp, read_data_str)
-    command(lmp, "pair_style snap")
-    command(lmp, "pair_coeff * * GaN.snapcoeff GaN.snapparam Ga N")
+    command(lmp, "pair_style zero $rcut")
+    command(lmp, "pair_coeff * *")
     command(lmp, "compute PE all pe")
     command(lmp, "compute S all pressure thermo_temp")
-    command(lmp, "compute SNA all sna/atom 3.5 0.99363 6 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
-    command(lmp, "compute SNAD all snad/atom 3.5 0.99363 6 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
-    command(lmp, "compute SNAV all snav/atom 3.5 0.99363 6 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
+    command(lmp, "compute SNA all sna/atom $rcut 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
+    command(lmp, "compute SNAD all snad/atom $rcut 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
+    command(lmp, "compute SNAV all snav/atom $rcut 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
     command(lmp, "thermo_style custom pe")
-    command(lmp, "dump 2 all custom 100 dump.forces fx fy fz")
+    #command(lmp, "dump 2 all custom 100 dump.forces fx fy fz")
     command(lmp, "run 0")
     nlocal = extract_global(lmp, "nlocal")
     types = extract_atom(lmp, "type", LAMMPS.API.LAMMPS_INT)
     ids = extract_atom(lmp, "id", LAMMPS.API.LAMMPS_INT)
     bs = extract_compute(lmp, "SNA", LAMMPS.API.LMP_STYLE_ATOM,
                                      LAMMPS.API.LMP_TYPE_ARRAY)
+    
+
     E_tot_acc = 0.0
     for n in 1:N1
         E_atom_acc = β[1]

--- a/examples/snap/snap.jl
+++ b/examples/snap/snap.jl
@@ -9,6 +9,7 @@ using LAMMPS
 # b - energies, forces, stresses
 ###
 
+const rcut = 3.5
 const ntypes = 2
 const twojmax = 6
 
@@ -24,20 +25,21 @@ A = LMP(["-screen","none"]) do lmp
     for m in 1:M
         read_data_str = "read_data " * joinpath("data", string(m), "DATA")
 
+        command(lmp, "log none")
         command(lmp, "units metal")
         command(lmp, "boundary p p p")
         command(lmp, "atom_style atomic")
         command(lmp, "atom_modify map array")
         command(lmp, read_data_str)
-        command(lmp, "pair_style zero 3.5")
+        command(lmp, "pair_style zero $rcut")
         command(lmp, "pair_coeff * *")
         command(lmp, "compute PE all pe")
         command(lmp, "compute S all pressure thermo_temp")
-        command(lmp, "compute SNA all sna/atom 3.5 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
-        command(lmp, "compute SNAD all snad/atom 3.5 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
-        command(lmp, "compute SNAV all snav/atom 3.5 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
+        command(lmp, "compute SNA all sna/atom $rcut 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
+        command(lmp, "compute SNAD all snad/atom $rcut 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
+        command(lmp, "compute SNAV all snav/atom $rcut 0.99363 $twojmax 0.5 0.5 1.0 0.5 rmin0 0.0 bzeroflag 0 quadraticflag 0 switchflag 1")
         command(lmp, "thermo_style custom pe")
-        command(lmp, "dump 2 all custom 100 dump.forces fx fy fz")
+        #command(lmp, "dump 2 all custom 100 dump.forces fx fy fz") # No need to dump the forces
         command(lmp, "run 0")
 
         nlocal = extract_global(lmp, "nlocal")


### PR DESCRIPTION
This is a nice example. I made some changes to make it more general:

- We don't need to use the SNAP pair style, so I used a "zero" pair style.
- Variables `rcut` and `twojmax` are input to the LAMMPS commands, makes it clear how these variables are used.
- No need to dump a big LAMMPS log file or dump.forces file.