### PR TITLE
Minor improvements

### DIFF
--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -47,6 +47,11 @@ function set_library!(path)
     end
 end
 
+"""
+    LMP(args::Vector{String}=String[], comm::Union{Nothing, MPI.Comm}=nothing)
+
+Create a new LAMMPS instance while passing in a list of strings as if they were command-line arguments for the LAMMPS executable.
+"""
 mutable struct LMP
     @atomic handle::Ptr{Cvoid}
 
@@ -77,7 +82,7 @@ Base.unsafe_convert(::Type{Ptr{Cvoid}}, lmp::LMP) = lmp.handle
 """
     close!(lmp::LMP)
 
-Shutdown an LMP instance.
+Shutdown an LAMMPS instance.
 """
 function close!(lmp::LMP)
     handle = @atomicswap lmp.handle = C_NULL
@@ -86,6 +91,12 @@ function close!(lmp::LMP)
     end
 end
 
+"""
+    LMP(f::Function, args=String[], comm=nothing)
+
+Create a new LAMMPS instance and call `f` on that instance while returning the result from `f`.
+This constructor closes the LAMMPS instance immediately after `f` has executed.
+"""
 function LMP(f::Function, args=String[], comm=nothing)
     lmp = LMP(args, comm)
     result = f(lmp)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -107,12 +107,32 @@ end
 
 
 """
-    command(lmp::lmp, cmd)
+    command(lmp::LMP, cmd::Union{String, Array{String}})
+
+Process LAMMPS input commands from a String or from an Array of Strings.
+
+For a full list of commands see: https://docs.lammps.org/commands_list.html
+
+This function processes a multi-line string similar to a block of commands from a file.
+The string may have multiple lines (separated by newline characters) and also single commands may
+be distributed over multiple lines with continuation characters (’&’).
+Those lines are combined by removing the ‘&’ and the following newline character.
+After this processing the string is handed to LAMMPS for parsing and executing.
+
+Arrays of Strings get concatenated into a single String inserting newline characters as needed.
+
+!!! warn "Newline Characters"
+    Old versions of this package (0.4.0 or older) used to ignore newline characters,
+    such that `cmd` would allways be treated as a single command. In newer version this is no longer the case.
 """
-function command(lmp::LMP, cmd)
-    ptr = API.lammps_command(lmp, cmd)
-    ptr == C_NULL && check(lmp)
-    nothing
+function command(lmp::LMP, cmd::Union{String, Array{String}})
+    if cmd isa String
+        API.lammps_commands_string(lmp, cmd)
+    else
+        API.lammps_commands_list(lmp, length(cmd), cmd)
+    end
+
+    check(lmp)
 end
 
 """

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -51,6 +51,8 @@ end
     LMP(args::Vector{String}=String[], comm::Union{Nothing, MPI.Comm}=nothing)
 
 Create a new LAMMPS instance while passing in a list of strings as if they were command-line arguments for the LAMMPS executable.
+
+For a full ist of Command-line options see: https://docs.lammps.org/Run_options.html
 """
 mutable struct LMP
     @atomic handle::Ptr{Cvoid}

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -101,7 +101,7 @@ function check(lmp::LMP)
         # TODO: Check err == 1 or err == 2 (MPI)
         buf = zeros(UInt8, 100)
         API.lammps_get_last_error_message(lmp, buf, length(buf))
-        error(String(buf))
+        error(rstrip(String(buf), '\0'))
     end
 end
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -3,7 +3,7 @@ import MPI
 include("api.jl")
 
 export LMP, command, get_natoms, extract_atom, extract_compute, extract_global,
-       gather, scatter!, group_to_atom_ids, get_category_ids, close!
+       gather, scatter!, group_to_atom_ids, get_category_ids
 
 using Preferences
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -3,7 +3,7 @@ import MPI
 include("api.jl")
 
 export LMP, command, get_natoms, extract_atom, extract_compute, extract_global,
-       gather, scatter!
+       gather, scatter!, group_to_atom_ids, get_category_ids, close!
 
 using Preferences
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -88,7 +88,9 @@ end
 
 function LMP(f::Function, args=String[], comm=nothing)
     lmp = LMP(args, comm)
-    f(lmp)
+    result = f(lmp)
+    close!(lmp)
+    return result
 end
 
 function version(lmp::LMP)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -136,7 +136,7 @@ After this processing the string is handed to LAMMPS for parsing and executing.
 
 Arrays of Strings get concatenated into a single String inserting newline characters as needed.
 
-!!! warn "Newline Characters"
+!!! warning "Newline Characters"
     Old versions of this package (0.4.0 or older) used to ignore newline characters,
     such that `cmd` would allways be treated as a single command. In newer version this is no longer the case.
 """

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -82,7 +82,7 @@ Base.unsafe_convert(::Type{Ptr{Cvoid}}, lmp::LMP) = lmp.handle
 """
     close!(lmp::LMP)
 
-Shutdown an LAMMPS instance.
+Shutdown a LAMMPS instance.
 """
 function close!(lmp::LMP)
     handle = @atomicswap lmp.handle = C_NULL


### PR DESCRIPTION
I've added two API functions i've deemed usefull for my usecase. I think these will come in handy for anyone else using this Library.

While I was at it, I've also updated the documentation on `command()` and changed how it handles newline characters.
While this is technically a breaking change, I think that this should be fine, as most people probably don't have newlines in their command strings anyways. Doing it this way makes it a lot easier to work with the `command()` function I think...

I've also exported `close!()` and made sure that `LMP(f,...)` calls `close!` on the LAMMPS instance as that's what you'd expect to happen when using this variant of the constructor.