### PR TITLE
fix-examples

### DIFF
--- a/examples/lj_forces.jl
+++ b/examples/lj_forces.jl
@@ -42,5 +42,5 @@ command(lmp, "compute pot_e all pe")
 command(lmp, "run 0")
 
 # extract output
-forces = gather(lmp, "f")
-energies = gather(lmp, "pot_e")
+forces = gather(lmp, "f", Float64)
+energies = extract_compute(lmp, "pot_e", LAMMPS.API.LMP_STYLE_GLOBAL, LAMMPS.API.LMP_TYPE_SCALAR)

--- a/examples/snap.jl
+++ b/examples/snap.jl
@@ -40,7 +40,7 @@ function run_snap(lmp, path, rcut, twojmax)
     """)
 
     ## Extract bispectrum
-    bs = gather(lmp, "SNA", Float64)
+    bs = gather(lmp, "c_SNA", Float64)
     return bs
 end
 


### PR DESCRIPTION
`pot_e` is not a per atom-style but instead a global-style entity, so `gather` doesn't work for it. In fact, trying to gather `c_pot_e` causes a crash. I think I've found a way to prevent the crash, so I'll try to implement this later today.