### PR TITLE
Rework-API

### DIFF
--- a/examples/lj_forces.jl
+++ b/examples/lj_forces.jl
@@ -42,5 +42,5 @@ command(lmp, "compute pot_e all pe")
 command(lmp, "run 0")
 
 # extract output
-forces = gather(lmp, "f")
-energies = gather(lmp, "pot_e")
+forces = gather(lmp, "f", LAMMPS_DOUBLE_2D)
+energies = extract_compute(lmp, "pot_e", STYLE_GLOBAL, TYPE_SCALAR)

--- a/examples/snap.jl
+++ b/examples/snap.jl
@@ -40,7 +40,7 @@ function run_snap(lmp, path, rcut, twojmax)
     """)
 
     ## Extract bispectrum
-    bs = gather(lmp, "SNA", Float64)
+    bs = gather(lmp, "c_SNA", LAMMPS_DOUBLE_2D)
     return bs
 end
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -574,13 +574,13 @@ Compute entities have the prefix `c_`, fix entities use the prefix `f_`, and per
     However, LAMMPS only issues a warning if that's the case, which unfortuately cannot be detected through the underlying API.
     Starting form LAMMPS version `17 Apr 2024` this should no longer be an issue, as LAMMPS then throws an error instead of a warning.
 """
-function scatter!(lmp::LMP, name::String, data::T, ids::Union{Nothing, Array{Int32}}=nothing) where T<:VecOrMat
+function scatter!(lmp::LMP, name::String, data::VecOrMat{T}, ids::Union{Nothing, Array{Int32}}=nothing) where T<:Union{Float64, Int32}
     name == "mass" && error("scattering/gathering mass is currently not supported! Use `extract_atom()` instead.")
 
     count = _get_count(lmp, name)
     _T = _get_dtype(lmp, name)
 
-    @assert Int(array2type(T)) == _T
+    @assert Int(array2type(typeof(data))) in _T
 
     dtype = (T === Float64)
     natoms = get_natoms(lmp)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -7,6 +7,38 @@ export LMP, command, get_natoms, extract_atom, extract_compute, extract_global,
 
 using Preferences
 
+struct _LMP_DATATYPE{N}  end
+
+const LAMMPS_INT = _LMP_DATATYPE{0}()
+const LAMMPS_INT_2D = _LMP_DATATYPE{1}()
+const LAMMPS_DOUBLE = _LMP_DATATYPE{2}()
+const LAMMPS_DOUBLE_2D = _LMP_DATATYPE{3}()
+const LAMMPS_INT64 = _LMP_DATATYPE{4}()
+const LAMMPS_INT64_2D = _LMP_DATATYPE{5}()
+const LAMMPS_STRING = _LMP_DATATYPE{6}()
+
+struct _LMP_TYPE{N} end
+
+const TYPE_SCALAR = _LMP_TYPE{0}()
+const TYPE_VECTOR = _LMP_TYPE{1}()
+const TYPE_ARRAY = _LMP_TYPE{2}()
+const SIZE_VECTOR = _LMP_TYPE{3}()
+const SIZE_ROWS = _LMP_TYPE{4}()
+const SIZE_COLS = _LMP_TYPE{5}()
+
+struct _LMP_STYLE{N} end
+
+const STYLE_GLOBAL = _LMP_STYLE{0}()
+const STYLE_ATOM = _LMP_STYLE{1}()
+const STYLE_LOCAL = _LMP_STYLE{2}()
+
+struct LMP_VARIABLE{N} end
+
+const VARIABLE_EQUAL = LMP_VARIABLE{0}()
+const VARIABLE_ATOM = LMP_VARIABLE{1}()
+const VARIABLE_VECTOR = LMP_VARIABLE{2}()
+const VARIABLE_STRING = LMP_VARIABLE{3}()
+
 """
     locate()
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -277,13 +277,13 @@ function type2julia(type::_LMP_DATATYPE)
 end
 
 function array2type(array)
-    array isa Vector{Int32} && return LAMMPS_INT
-    array isa Matrix{Int32} && return LAMMPS_INT_2D
-    array isa Vector{Float64} && return LAMMPS_DOUBLE
-    array isa Matrix{Float64} && return LAMMPS_DOUBLE_2D
-    array isa Vector{Int64} && return LAMMPS_INT64
-    array isa Matrix{Int64} && return LAMMPS_INT64_2D
-    array isa String && return LAMMPS_STRING
+    array === Vector{Int32} && return LAMMPS_INT
+    array === Matrix{Int32} && return LAMMPS_INT_2D
+    array === Vector{Float64} && return LAMMPS_DOUBLE
+    array === Matrix{Float64} && return LAMMPS_DOUBLE_2D
+    array === Vector{Int64} && return LAMMPS_INT64
+    array === Matrix{Int64} && return LAMMPS_INT64_2D
+    array === String && return LAMMPS_STRING
 end
 
 is_2D(N::Integer) = N in (1, 3, 5)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -334,7 +334,7 @@ function lammps_unsafe_string(ptr::Ptr, copy=true)
 end
 
 function lammps_unsafe_wrap(ptr::Ptr{<:Real}, shape::Integer, copy=true)
-    result = Base.unsafe_wrap(Array, ptr, shape, own=own)
+    result = Base.unsafe_wrap(Array, ptr, shape, own=false)
     return copy ? Base.copy(result) : result
 end
 
@@ -346,7 +346,7 @@ function lammps_unsafe_wrap(ptr::Ptr{<:Ptr{T}}, shape::NTuple{2}, copy=true) whe
     pointers = Base.unsafe_wrap(Array, ptr, ndata)
 
     @assert all(diff(pointers) .== count*sizeof(T))
-    result = Base.unsafe_wrap(Array, pointers[1], shape, own=own)
+    result = Base.unsafe_wrap(Array, pointers[1], shape, own=false)
 
     return copy ? Base.copy(result) : result
 end

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -276,7 +276,7 @@ function type2julia(type::_LMP_DATATYPE)
     type == LAMMPS_STRING && return String
 end
 
-function array2type(array::Union{VecOrMat, String})
+function array2type(array)
     array isa Vector{Int32} && return LAMMPS_INT
     array isa Matrix{Int32} && return LAMMPS_INT_2D
     array isa Vector{Float64} && return LAMMPS_DOUBLE

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -369,53 +369,47 @@ function extract_compute(lmp::LMP, name::String, style::_LMP_STYLE, type::_LMP_T
 end
 
 """
-    extract_variable(lmp::LMP, name, group)
+    extract_variable(lmp::LMP, name::String, variable::LMP_VARIABLE, group=C_NULL; copy=true)
 
 Extracts the data from a LAMMPS variable. When the variable is either an `equal`-style compatible variable,
 a `vector`-style variable, or an `atom`-style variable, the variable is evaluated and the corresponding value(s) returned.
 Variables of style `internal` are compatible with `equal`-style variables, if they return a numeric value.
 For other variable styles, their string value is returned.
 """
-function extract_variable(lmp::LMP, name::String, group=nothing)
-    var = API.lammps_extract_variable_datatype(lmp, name)
-    if var == -1
-        throw(KeyError(name))
-    end
-    if group === nothing
-        group = C_NULL
+function extract_variable(lmp::LMP, name::String, variable::LMP_VARIABLE, group=C_NULL; copy=true)
+    @assert variable == VARIABLE_ATOM || group == C_NULL "the group parameter is only supported for per atom variables!"
+    @assert API.lammps_extract_variable_datatype(lmp, name) == Int(variable)
+
+    void_ptr = API.lammps_extract_variable(lmp, name, group)
+    @assert void_ptr != C_NULL
+
+    if variable == VARIABLE_EQUAL
+        ptr = lammps_reinterpret(LAMMPS_DOUBLE, void_ptr)
+        result = unsafe_load(ptr)
+        API.lammps_free(ptr)
+        return result
     end
 
-    if var == API.LMP_VAR_EQUAL
-        ptr = API.lammps_extract_variable(lmp, name, C_NULL)
-        val = Base.unsafe_load(Base.unsafe_convert(Ptr{Float64}, ptr))
-        API.lammps_free(ptr)
-        return val
-    elseif var == API.LMP_VAR_ATOM
-        nlocal = extract_global(lmp, "nlocal")
-        ptr = API.lammps_extract_variable(lmp, name, group)
-        if ptr == C_NULL
-            error("Group $group for variable $name with style atom not available.")
-        end
-        # LAMMPS uses malloc, so and we are taking ownership of this buffer
-        val = copy(Base.unsafe_wrap(Array, Base.unsafe_convert(Ptr{Float64}, ptr), nlocal; own=false))
-        API.lammps_free(ptr)
-        return val
-    elseif var == API.LMP_VAR_VECTOR
-        # TODO Fix lammps docs `GET_VECTOR_SIZE`
-        ptr = API.lammps_extract_variable(lmp, name, "LMP_SIZE_VECTOR")
-        if ptr == C_NULL
-            error("$name is a vector style variable but has no size.")
-        end
-        sz = Base.unsafe_load(Base.unsafe_convert(Ptr{Cint}, ptr))
-        API.lammps_free(ptr)
-        ptr = API.lammps_extract_variable(lmp, name, C_NULL)
-        return Base.unsafe_wrap(Array, Base.unsafe_convert(Ptr{Float64}, ptr), sz, own=false)
-    elseif var == API.LMP_VAR_STRING
-        ptr = API.lammps_extract_variable(lmp, name, C_NULL)
-        return Base.unsafe_string(Base.unsafe_convert(Ptr{Cchar}, ptr))
-    else
-        error("Unkown variable style $var")
+    if variable == VARIABLE_VECTOR
+        ndata_ptr = lammps_reinterpret(LAMMPS_INT, API.lammps_extract_variable(lmp, name, "GET_VECTOR_SIZE"))
+        ndata = unsafe_load(ndata_ptr)
+        API.lammps_free(ndata_ptr)
+
+        ptr = lammps_reinterpret(LAMMPS_DOUBLE, void_ptr)
+        return lammps_unsafe_wrap(ptr, ndata, copy)
     end
+
+    if variable == VARIABLE_ATOM
+        ndata = extract_setting(lmp, "nlocal")
+
+        ptr = lammps_reinterpret(LAMMPS_DOUBLE, void_ptr)
+        result = lammps_unsafe_wrap(ptr, ndata, true)
+        API.lammps_free(ptr)
+        return result
+    end
+
+    ptr = lammps_reinterpret(LAMMPS_STRING, void_ptr)
+    return lammps_unsafe_string(ptr, copy)
 end
 
 @deprecate gather_atoms(lmp::LMP, name, T, count) gather(lmp, name, T)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -173,13 +173,10 @@ end
     LMP(f::Function, args=String[], comm=nothing)
 
 Create a new LAMMPS instance and call `f` on that instance while returning the result from `f`.
-This constructor closes the LAMMPS instance immediately after `f` has executed.
 """
 function LMP(f::Function, args=String[], comm=nothing)
     lmp = LMP(args, comm)
-    result = f(lmp)
-    close!(lmp)
-    return result
+    return f(lmp)
 end
 
 function version(lmp::LMP)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -1,11 +1,55 @@
 module LAMMPS
+
 import MPI
+using Preferences
+
 include("api.jl")
 
-export LMP, command, get_natoms, extract_atom, extract_compute, extract_global,
-       gather, scatter!, group_to_atom_ids, get_category_ids
-
-using Preferences
+export
+# Core 
+    LMP,
+    command,
+    get_natoms,
+# Gather/Scatter operations
+    gather,
+    scatter!,
+    gather_angles,
+    gather_bonds,
+    gather_dihedrals,
+    gather_impropers,
+# Extracts
+    extract_setting,
+    extract_atom,
+    extract_compute,
+    extract_global,
+    extract_variable,
+# Utilities
+    group_to_atom_ids,
+    get_category_ids,
+# Datatypes
+    LAMMPS_INT,
+    LAMMPS_INT_2D,
+    LAMMPS_DOUBLE,
+    LAMMPS_DOUBLE_2D,
+    LAMMPS_INT64,
+    LAMMPS_INT64_2D,
+    LAMMPS_STRING,
+# Types
+    TYPE_SCALAR,
+    TYPE_VECTOR,
+    TYPE_ARRAY,
+    SIZE_COLS,
+    SIZE_ROWS,
+    SIZE_VECTOR,
+# Styles
+    STYLE_GLOBAL,
+    STYLE_ATOM,
+    STYLE_LOCAL,
+# Variables
+    VARIABLE_EQUAL,
+    VARIABLE_ATOM,
+    VARIABLE_VECTOR,
+    VARIABLE_STRING
 
 struct _LMP_DATATYPE{N}  end
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -478,6 +478,46 @@ function gather(lmp::LMP, name::String, T::_LMP_DATATYPE, ids::Union{Nothing, Ar
     return data
 end
 
+function gather_bonds(lmp::LMP)
+    nbonds = extract_global(lmp, "nbonds", LAMMPS_INT64, copy=false)[]
+    data = Matrix{Int32}(undef, (3, nbonds))
+    API.lammps_gather_bonds(lmp, data)
+    return data
+end
+
+function gather_angles(lmp::LMP)
+    nangles = extract_global(lmp, "nangles", LAMMPS_INT64, copy=false)[]
+    data = Matrix{Int32}(undef, (4, nangles))
+    API.lammps_gather_angles(lmp, data)
+    return data
+end
+
+function gather_dihedrals(lmp::LMP)
+    ndihedrals = extract_global(lmp, "ndihedrals", LAMMPS_INT64, copy=false)[]
+    data = Matrix{Int32}(undef, (5, ndihedrals))
+    API.lammps_gather_dihedrals(lmp, data)
+    return data
+end
+
+function gather_impropers(lmp::LMP)
+    nimpropers = extract_global(lmp, "nimpropers", LAMMPS_INT64, copy=false)[]
+    data = Matrix{Int32}(undef, (5, nimpropers))
+    API.lammps_gather_impropers(lmp, data)
+    return data
+end
+
+function create_atoms(lmp::LMP, type, x; id=nothing, v=nothing, image=nothing, bexpand=false)
+    natoms = length(type)
+
+    @assert size(x) == (3, natoms)
+
+    isnothing(id) ? id = C_NULL : @assert size(id) == natoms
+    isnothing(v) ? v = C_NULL : @assert size(v) == (3, natoms)
+    isnothing(image) ? image = C_NULL : @assert size(image) = natoms
+
+    return API.lammps_create_atoms(lmp, natoms, id, type, x, v, image, bexpand)
+end
+
 """
     scatter!(lmp::LMP, name::String, data::VecOrMat{T}, ids::Union{Nothing, Array{Int32}}=nothing) where T<:Union{Int32, Float64}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,26 +17,28 @@ end
 
 @testset "Variables" begin
     LMP(["-screen", "none"]) do lmp
-        command(lmp, "box tilt large")
-        command(lmp, "region cell block 0 1.0 0 1.0 0 1.0 units box")
-        command(lmp, "create_box 1 cell")
-        command(lmp, "create_atoms 1 random 10 1 NULL")
-        command(lmp, "compute  press all pressure NULL pair");
-        command(lmp, "fix press all ave/time 1 1 1 c_press mode vector");
+        command(lmp, """
+            box tilt large
+            region cell block 0 1.0 0 1.0 0 1.0 units box
+            create_box 1 cell
+            create_atoms 1 random 10 1 NULL
+            compute  press all pressure NULL pair
+            fix press all ave/time 1 1 1 c_press mode vector
 
-        command(lmp, "variable var1 equal 1.0")
-        command(lmp, "variable var2 string \"hello\"")
-        command(lmp, "variable var3 atom x")
-        # TODO: x is 3d, how do we access more than the first dims
-        command(lmp, "variable var4 vector f_press")
+            variable var1 equal 1.0
+            variable var2 string \"hello\"
+            variable var3 atom x
+            # TODO: x is 3d, how do we access more than the first dims
+            variable var4 vector f_press
+        """)
 
-        @test LAMMPS.extract_variable(lmp, "var1") == 1.0
-        @test LAMMPS.extract_variable(lmp, "var2") == "hello"
-        x = LAMMPS.extract_atom(lmp, "x")
-        x_var = LAMMPS.extract_variable(lmp, "var3")
+        @test extract_variable(lmp, "var1", VARIABLE_EQUAL) == 1.0
+        @test extract_variable(lmp, "var2", VARIABLE_STRING) == "hello"
+        x = extract_atom(lmp, "x", LAMMPS_DOUBLE_2D)
+        x_var = extract_variable(lmp, "var3", VARIABLE_ATOM)
         @test length(x_var) == 10
         @test x_var == x[1, :]
-        press = LAMMPS.extract_variable(lmp, "var4")
+        press = LAMMPS.extract_variable(lmp, "var4", VARIABLE_VECTOR)
         @test press isa Vector{Float64}
     end
 end
@@ -44,17 +46,20 @@ end
 @testset "gather/scatter" begin
     LMP(["-screen", "none"]) do lmp
         # setting up example data
-        command(lmp, "atom_modify map yes")
-        command(lmp, "region cell block 0 3 0 3 0 3")
-        command(lmp, "create_box 1 cell")
-        command(lmp, "lattice sc 1")
-        command(lmp, "create_atoms 1 region cell")
-        command(lmp, "mass 1 1")
+        command(lmp, """
+            atom_modify map yes
+            region cell block 0 3 0 3 0 3
+            create_box 1 cell
+            lattice sc 1
+            create_atoms 1 region cell
+            mass 1 1
 
-        command(lmp, "compute pos all property/atom x y z")
-        command(lmp, "fix pos all ave/atom 10 1 10 c_pos[1] c_pos[2] c_pos[3]")
+            compute pos all property/atom x y z
+            fix pos all ave/atom 10 1 10 c_pos[*]
 
-        command(lmp, "run 10")
+            run 10
+        """)
+        
         data = zeros(Float64, 3, 27)
         subset = Int32.([2,5,10, 5])
         data_subset = ones(Float64, 3, 4)
@@ -63,15 +68,15 @@ end
         subset_bad2 = Int32.([0])
         subset_bad_data = ones(Float64, 3,1)
 
-        @test_throws AssertionError gather(lmp, "x", Int32)
-        @test_throws AssertionError gather(lmp, "id", Float64)
+        @test_throws AssertionError gather(lmp, "x", LAMMPS_INT_2D)
+        @test_throws AssertionError gather(lmp, "id", LAMMPS_DOUBLE)
 
-        @test_throws ErrorException gather(lmp, "nonesense", Float64)
-        @test_throws ErrorException gather(lmp, "c_nonsense", Float64)
-        @test_throws ErrorException gather(lmp, "f_nonesense", Float64)
+        @test_throws ErrorException gather(lmp, "nonesense", LAMMPS_DOUBLE_2D)
+        @test_throws ErrorException gather(lmp, "c_nonsense", LAMMPS_DOUBLE_2D)
+        @test_throws ErrorException gather(lmp, "f_nonesense", LAMMPS_DOUBLE_2D)
 
-        @test_throws AssertionError gather(lmp, "x", Float64, subset_bad1)
-        @test_throws AssertionError gather(lmp, "x", Float64, subset_bad2)
+        @test_throws AssertionError gather(lmp, "x", LAMMPS_DOUBLE_2D, subset_bad1)
+        @test_throws AssertionError gather(lmp, "x", LAMMPS_DOUBLE_2D, subset_bad2)
 
         @test_throws ErrorException scatter!(lmp, "nonesense", data)
         @test_throws ErrorException scatter!(lmp, "c_nonsense", data)
@@ -80,23 +85,23 @@ end
         @test_throws AssertionError scatter!(lmp, "x", subset_bad_data, subset_bad1)
         @test_throws AssertionError scatter!(lmp, "x", subset_bad_data, subset_bad2)
 
-        @test gather(lmp, "x", Float64) == gather(lmp, "c_pos", Float64) == gather(lmp, "f_pos", Float64)
+        @test gather(lmp, "x", LAMMPS_DOUBLE_2D) == gather(lmp, "c_pos", LAMMPS_DOUBLE_2D) == gather(lmp, "f_pos", LAMMPS_DOUBLE_2D)
 
-        @test gather(lmp, "x", Float64)[:,subset] == gather(lmp, "x", Float64, subset)
-        @test gather(lmp, "c_pos", Float64)[:,subset] == gather(lmp, "c_pos", Float64, subset)
-        @test gather(lmp, "f_pos", Float64)[:,subset] == gather(lmp, "f_pos", Float64, subset)
+        @test gather(lmp, "x", LAMMPS_DOUBLE_2D)[:,subset] == gather(lmp, "x", LAMMPS_DOUBLE_2D, subset)
+        @test gather(lmp, "c_pos", LAMMPS_DOUBLE_2D)[:,subset] == gather(lmp, "c_pos", LAMMPS_DOUBLE_2D, subset)
+        @test gather(lmp, "f_pos", LAMMPS_DOUBLE_2D)[:,subset] == gather(lmp, "f_pos", LAMMPS_DOUBLE_2D, subset)
 
         scatter!(lmp, "x", data)
         scatter!(lmp, "f_pos", data)
         scatter!(lmp, "c_pos", data)
 
-        @test gather(lmp, "x", Float64) == gather(lmp, "c_pos", Float64) == gather(lmp, "f_pos", Float64) == data
+        @test gather(lmp, "x", LAMMPS_DOUBLE_2D) == gather(lmp, "c_pos", LAMMPS_DOUBLE_2D) == gather(lmp, "f_pos", LAMMPS_DOUBLE_2D) == data
 
         scatter!(lmp, "x", data_subset, subset)
         scatter!(lmp, "c_pos", data_subset, subset)
         scatter!(lmp, "f_pos", data_subset, subset)
 
-        @test gather(lmp, "x", Float64, subset) == gather(lmp, "c_pos", Float64, subset) == gather(lmp, "f_pos", Float64, subset) == data_subset
+        @test gather(lmp, "x", LAMMPS_DOUBLE_2D, subset) == gather(lmp, "c_pos", LAMMPS_DOUBLE_2D, subset) == gather(lmp, "f_pos", LAMMPS_DOUBLE_2D, subset) == data_subset
 
     end
 end


### PR DESCRIPTION
I got a bit carried away and reworked almost the entire API . There are a lot of breaking changes but I hope that these will be worthwile.

## Changes
 - I've replaced the Enums with Singletons 
     - These Singletons get exported so `LAMMPS.API.LMP_TYPE_VECTOR` reduces to `TYPE_VECTOR`
     - All `extract` methods should now be typestable!
 - Most `extracts` now have the kwarg `copy` which is true by default. I've done this because the pointers we recieve from LAMMPS are not persistent. I don't think it's a good idea to hand the user an Array that can suddenly cause a Segfault - at least not by default.
 - Most `extracts` now return Vectors with `length=1` instead of Scalar values, when setting `copy=false`, this allows the user to modify the underlying data. (This is partly because of type stability as well)
 - Computes/Fixes are allways of type `Float64`. With this assumption, `gather`/`scatter!` should now always detect incorrect types.
 - `gather` also uses the newly defined Singletons instead of `Float64/Int32` for the type parameter
     - This improves consistency across functions and allows the function to return a Vector or a Matrix while preserving type stability 
 - `gather_bonds`, `gather_angles`, `gather_dihedrals`, `gather_impropers`, `decode_image_flags`, `encode_image_flags`, `extract_setting`,  and `create_atoms`, `is_running` are now implemented

## Todo
 - unittests, docstrings, Descriptive error messages


It probably would have been better to split this up into multiple PR's 😅 