### PR TITLE
cleanup test depenencies

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,3 @@
 [deps]
-GalacticOptim = "a75be94c-b780-496d-a8a9-0878b188d577"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-Optim = "429524aa-4258-5aef-a3af-852621145aeb"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using MPI
 
 @test_logs (:warn,"LAMMPS library path changed, you will need to restart Julia for the change to take effect") LAMMPS.set_library!(LAMMPS.locate())
 
-LMP() do lmp
+LMP(["-screen", "none"]) do lmp
     @test LAMMPS.version(lmp) >= 0
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using MPI
 
 @test_logs (:warn,"LAMMPS library path changed, you will need to restart Julia for the change to take effect") LAMMPS.set_library!(LAMMPS.locate())
 
-LMP(["-screen", "none"]) do lmp
+LMP() do lmp
     @test LAMMPS.version(lmp) >= 0
 end
 


### PR DESCRIPTION
I've removed the test dependencies that we're not using. The automated tests should now work on julia v1.11