### PR TITLE
fix gather/scatter type verification

### DIFF
--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -616,10 +616,6 @@ Compute entities have the prefix `c_`, fix entities use the prefix `f_`, and per
 
 The returned Array is decoupled from the internal state of the LAMMPS instance.
 
-!!! warning "Type Verification"
-    Due to how the underlying C-API works, it's not possible to verify the element data-type of fix or compute style data.
-    Supplying the wrong data-type will not throw an error but will result in nonsensical output
-
 !!! warning "ids"
     The optional parameter `ids` only works, if there is a map defined. For example by doing:
     `command(lmp, "atom_modify map yes")`
@@ -658,10 +654,6 @@ By default (when `ids=nothing`), this method scatters data to all atoms in conse
 The optional parameter `ids` determines to which subset of atoms the data will be scattered.
 
 Compute entities have the prefix `c_`, fix entities use the prefix `f_`, and per-atom entites have no prefix.
-
-!!! warning "Type Verification"
-    Due to how the underlying C-API works, it's not possible to verify the element data-type of fix or compute style data.
-    Supplying the wrong data-type will not throw an error but will result in nonsensical date being supplied to the LAMMPS instance.
 
 !!! warning "ids"
     The optional parameter `ids` only works, if there is a map defined. For example by doing:
@@ -732,7 +724,7 @@ end
 
 function _get_T(lmp::LMP, name::String)
     if startswith(name, r"[f,c]_")
-        return missing # As far as I know, it's not possible to determine the datatype of computes or fixes at runtime
+        return Float64
     end
 
     type = API.lammps_extract_atom_datatype(lmp, name)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -724,7 +724,7 @@ end
 
 function _get_T(lmp::LMP, name::String)
     if startswith(name, r"[f,c]_")
-        return Float64
+        return Float64 # computes and fixes are allways doubles
     end
 
     type = API.lammps_extract_atom_datatype(lmp, name)


### PR DESCRIPTION
Computes and Fixes are allways doubles. This is just a small fixup - I think In the future we should use 
- `LAMMPS_INT`
- `LAMMPS_INT_2D`
- `LAMMPS_DOUBLE`
- `LAMMPS_DOUBLE_2D`

for the type parameter instead of `Int32` and `Float64`. This makes the API more consistent and we're able to return Vectors instead of 1xN Matrices while preserving type stability.