### PR TITLE
Add create_atoms function to LAMMPS.jl

### DIFF
--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -83,6 +83,16 @@ const BIGINT = API.lammps_extract_setting(C_NULL, "bigint") == 4 ? Int32 : Int64
 const TAGINT = API.lammps_extract_setting(C_NULL, "tagint") == 4 ? Int32 : Int64
 const IMAGEINT = API.lammps_extract_setting(C_NULL, "imageint") == 4 ? Int32 : Int64
 
+function __init__()
+    BIGINT != (API.lammps_extract_setting(C_NULL, "bigint") == 4 ? Int32 : Int64) &&
+        error("The size of the LAMMPS integer type BIGINT has changed! To fix this, you need to manually invalidate the LAMMPS.jl cache.")
+    TAGINT != (API.lammps_extract_setting(C_NULL, "tagint") == 4 ? Int32 : Int64) &&
+         error("The size of the LAMMPS integer type TAGINT has changed! To fix this, you need to manually invalidate the LAMMPS.jl cache.")
+     IMAGEINT != (API.lammps_extract_setting(C_NULL, "tagint") == 4 ? Int32 : Int64) &&
+         error("The size of the LAMMPS integer type IMAGEINT has changed! To fix this, you need to manually invalidate the LAMMPS.jl cache.")
+end
+
+
 """
     locate()
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -260,12 +260,12 @@ end
     )
 
 Create atoms for a LAMMPS instance. 
-x contains the atom positions and should be a 3 by Matrix{Float64}, where n is the number of atoms. 
-id contains the id of each atom and should all be Vector{Int32} with length n.
-types contains the atomic type (LAMMPS number) of each atom and should all be a Vector{Int32} with length n.
-v contains the associated velocities and should be a 3 by Matrix{Float64}.
-image contains the image flags for each atom and should be Vector{IMAGEINT} with length n.
-bexpand is a Bool that defines whether or not the box should be expanded to fit the input atoms (default not).
+`x` contains the atom positions and should be a 3 by `n` `Matrix{Float64}`, where `n` is the number of atoms. 
+`id` contains the id of each atom and should be a length `n` `Vector{Int32}`.
+`types` contains the atomic type (LAMMPS number) of each atom and should be a length `n` `Vector{Int32}`.
+`v ` contains the associated velocities and should be a 3 by `n` `Matrix{Float64}`.
+`image` contains the image flags for each atom and should be a length `n` `Vector{IMAGEINT}`.
+`bexpand` is a `Bool` that defines whether or not the box should be expanded to fit the input atoms (default not).
 """
 function create_atoms(
     lmp::LMP, x::Matrix{Float64}, id::Vector{Int32}, types::Vector{Int32};

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -244,8 +244,8 @@ end
 """
     create_atoms(
         lmp::LMP, x::Matrix{Float64}, id::Vector{Int32}, types::Vector{Int32};
-        v::Union{Ptr{Float64},Matrix{Float64}}=Ptr{Float64}(C_NULL),
-        image::Union{Ptr{IMAGEINT},Vector{IMAGEINT}}=Ptr{IMAGEINT}(C_NULL),
+        v::Union{Nothing,Matrix{Float64}}=nothing,
+        image::Union{Nothing,Vector{IMAGEINT}}=nothing,
         bexpand::Bool=false
     )
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -259,8 +259,8 @@ bexpand is a Bool that defines whether or not the box should be expanded to fit 
 """
 function create_atoms(
     lmp::LMP, x::Matrix{Float64}, id::Vector{Int32}, types::Vector{Int32};
-    v::Union{Ptr{Float64},Matrix{Float64}}=Ptr{Float64}(C_NULL),
-    image::Union{Ptr{IMAGEINT},Vector{IMAGEINT}}=Ptr{IMAGEINT}(C_NULL),
+    v::Union{Nothing,Matrix{Float64}}=nothing,
+    image::Union{Nothing,Vector{IMAGEINT}}=nothing,
     bexpand::Bool=false
 )
     numAtoms = size(x, 2)
@@ -273,12 +273,15 @@ function create_atoms(
     if numAtoms != length(types)
         throw(ArgumentError("types must have the same length as the number of atoms"))
     end
-    if typeof(v) != Ptr{Float64} && size(x) != size(v)
+    if v != nothing && size(x) != size(v)
         throw(ArgumentError("x and v must be the same size"))
     end
-    if typeof(image) != Ptr{IMAGEINT} && numAtoms != length(image)
+    if image != nothing && numAtoms != length(image)
         throw(ArgumentError("image must have the same length as the number of atoms"))
     end
+
+    v = v == nothing ? Ptr{Float64}(C_NULL) : v
+    image = image == nothing ? Ptr{IMAGEINT}(C_NULL) : image
 
     API.lammps_create_atoms(lmp.handle, numAtoms, id, types, x, v, image, bexpand ? 1 : 0)
 end

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -263,7 +263,7 @@ Create atoms for a LAMMPS instance.
 `x` contains the atom positions and should be a 3 by `n` `Matrix{Float64}`, where `n` is the number of atoms. 
 `id` contains the id of each atom and should be a length `n` `Vector{Int32}`.
 `types` contains the atomic type (LAMMPS number) of each atom and should be a length `n` `Vector{Int32}`.
-`v ` contains the associated velocities and should be a 3 by `n` `Matrix{Float64}`.
+`v` contains the associated velocities and should be a 3 by `n` `Matrix{Float64}`.
 `image` contains the image flags for each atom and should be a length `n` `Vector{IMAGEINT}`.
 `bexpand` is a `Bool` that defines whether or not the box should be expanded to fit the input atoms (default not).
 """

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -33,8 +33,12 @@ export LMP, command, create_atoms, get_natoms, extract_atom, extract_compute, ex
        # _LMP_STYLE_CONST
        STYLE_GLOBAL,
        STYLE_ATOM,
-       STYLE_LOCAL
+       STYLE_LOCAL,
 
+       # LAMMPS to Julia types
+       BIGINT,
+       TAGINT,
+       IMAGEINT
 
 using Preferences
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -283,7 +283,7 @@ function create_atoms(
     v = v == nothing ? C_NULL : v
     image = image == nothing ? C_NULL : image
 
-    API.lammps_create_atoms(lmp.handle, numAtoms, id, types, x, v, image, bexpand ? 1 : 0)
+    API.lammps_create_atoms(lmp, numAtoms, id, types, x, v, image, bexpand ? 1 : 0)
 end
 
 """

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -280,8 +280,8 @@ function create_atoms(
         throw(ArgumentError("image must have the same length as the number of atoms"))
     end
 
-    v = v == nothing ? Ptr{Float64}(C_NULL) : v
-    image = image == nothing ? Ptr{IMAGEINT}(C_NULL) : image
+    v = v == nothing ? C_NULL : v
+    image = image == nothing ? C_NULL : image
 
     API.lammps_create_atoms(lmp.handle, numAtoms, id, types, x, v, image, bexpand ? 1 : 0)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -333,7 +333,7 @@ end
         @test_throws ArgumentError create_atoms(lmp, x[1:2,:], id, types; v, image, bexpand=true) 
         @test_throws ArgumentError create_atoms(lmp, x, id[1:99], types; v, image, bexpand=true) 
         @test_throws ArgumentError create_atoms(lmp, x, id, types[1:99]; v, image, bexpand=true) 
-        @test_throws ArgumentError create_atoms(lmp, x, id, types; v=v[1:2,:]; image, bexpand=true) 
+        @test_throws ArgumentError create_atoms(lmp, x, id, types; v=v[1:2,:], image, bexpand=true)
         @test_throws ArgumentError create_atoms(lmp, x, id, types; v, image=image[1:99], bexpand=true) 
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -336,14 +336,6 @@ end
         @test_throws ArgumentError create_atoms(lmp, x, id, types, v=v[1:2,:], image=image, bexpand=true) 
         @test_throws ArgumentError create_atoms(lmp, x, id, types, v=v, image=image[1:99], bexpand=true) 
 
-        warnMsg = " does not match type expected by LAMMPS. "*
-                  "This causes allocation!!! "*
-                  "Change typeof "
-        @test_throws ArgumentError create_atoms(lmp, Float32.(x), id, types, v=v, image=image, bexpand=true)
-        @test_throws ArgumentError create_atoms(lmp, x, Int64.(id), types, v=v, image=image, bexpand=true)
-        @test_throws ArgumentError create_atoms(lmp, x, id, Int64.(types), v=v, image=image, bexpand=true)
-        @test_throws ArgumentError create_atoms(lmp, x, id, types, v=Float32.(v), image=image, bexpand=true)
-        @test_throws ArgumentError create_atoms(lmp, x, id, types, v=v, image=Int64.(image), bexpand=true)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -339,11 +339,11 @@ end
         warnMsg = " does not match type expected by LAMMPS. "*
                   "This causes allocation!!! "*
                   "Change typeof "
-        @test_warn "Typeof x"*warnMsg*"x to Matrix{Float64}." create_atoms(lmp, Float32.(x), id, types, v=v, image=image, bexpand=true)
-        @test_warn "Typeof id"*warnMsg*"id to Vector{Int32}." create_atoms(lmp, x, Int64.(id), types, v=v, image=image, bexpand=true)
-        @test_warn "Typeof types"*warnMsg*"types to Vector{Int32}." create_atoms(lmp, x, id, Int64.(types), v=v, image=image, bexpand=true)
-        @test_warn "Typeof v"*warnMsg*"v to Matrix{Float64}." create_atoms(lmp, x, id, types, v=Float32.(v), image=image, bexpand=true)
-        @test_warn "Typeof image"*warnMsg*"image to Vector{Int32}." create_atoms(lmp, x, id, types, v=v, image=Int64.(image), bexpand=true)
+        @test_throws ArgumentError create_atoms(lmp, Float32.(x), id, types, v=v, image=image, bexpand=true)
+        @test_throws ArgumentError create_atoms(lmp, x, Int64.(id), types, v=v, image=image, bexpand=true)
+        @test_throws ArgumentError create_atoms(lmp, x, id, Int64.(types), v=v, image=image, bexpand=true)
+        @test_throws ArgumentError create_atoms(lmp, x, id, types, v=Float32.(v), image=image, bexpand=true)
+        @test_throws ArgumentError create_atoms(lmp, x, id, types, v=v, image=Int64.(image), bexpand=true)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -330,7 +330,7 @@ end
             lmp, "v", LAMMPS_DOUBLE_2D
         ))
 
-        @test_throws ArgumentError create_atoms(lmp, x[1:2,:], id, types, v=v, image=image, bexpand=true) 
+        @test_throws ArgumentError create_atoms(lmp, x[1:2,:], id, types; v, image, bexpand=true) 
         @test_throws ArgumentError create_atoms(lmp, x, id[1:99], types, v=v, image=image, bexpand=true) 
         @test_throws ArgumentError create_atoms(lmp, x, id, types[1:99], v=v, image=image, bexpand=true) 
         @test_throws ArgumentError create_atoms(lmp, x, id, types, v=v[1:2,:], image=image, bexpand=true) 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,10 +331,10 @@ end
         ))
 
         @test_throws ArgumentError create_atoms(lmp, x[1:2,:], id, types; v, image, bexpand=true) 
-        @test_throws ArgumentError create_atoms(lmp, x, id[1:99], types, v=v, image=image, bexpand=true) 
-        @test_throws ArgumentError create_atoms(lmp, x, id, types[1:99], v=v, image=image, bexpand=true) 
-        @test_throws ArgumentError create_atoms(lmp, x, id, types, v=v[1:2,:], image=image, bexpand=true) 
-        @test_throws ArgumentError create_atoms(lmp, x, id, types, v=v, image=image[1:99], bexpand=true) 
+        @test_throws ArgumentError create_atoms(lmp, x, id[1:99], types; v, image, bexpand=true) 
+        @test_throws ArgumentError create_atoms(lmp, x, id, types[1:99]; v, image, bexpand=true) 
+        @test_throws ArgumentError create_atoms(lmp, x, id, types; v=v[1:2,:]; image, bexpand=true) 
+        @test_throws ArgumentError create_atoms(lmp, x, id, types; v, image=image[1:99], bexpand=true) 
 
     end
 end


### PR DESCRIPTION
It is useful (at least for me) to be able to load atoms directly from Julia to LAMMPS. This pull request provides a wrapper around ```lammps_create_atoms``` to easily do this, similar to the [create_atoms](https://docs.lammps.org/Python_module.html#lammps.lammps.create_atoms) function in the python interface to LAMMPS.