### PR TITLE
make extract_atom, extract_global, and gather typestable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.jl.mem
 
 Manifest.toml
+LocalPreferences.toml
 
 # generated docs
 docs/build/

--- a/examples/lj_forces.jl
+++ b/examples/lj_forces.jl
@@ -34,7 +34,7 @@ command(lmp, """
 
 # (x,y,z), natoms
 positions = rand(3, 10) .* 5
-scatter!(lmp, "x", positions)
+scatter!(lmp, :x, positions)
 
 # Compute pot_e
 command(lmp, "compute pot_e all pe")
@@ -42,5 +42,5 @@ command(lmp, "compute pot_e all pe")
 command(lmp, "run 0")
 
 # extract output
-forces = gather(lmp, "f", Float64)
-energies = extract_compute(lmp, "pot_e", STYLE_GLOBAL, TYPE_SCALAR)
+forces = gather(lmp, :f)
+energies = extract_compute(lmp, :pot_e, STYLE_GLOBAL, TYPE_SCALAR)

--- a/examples/snap.jl
+++ b/examples/snap.jl
@@ -40,7 +40,7 @@ function run_snap(lmp, path, rcut, twojmax)
     """)
 
     ## Extract bispectrum
-    bs = gather(lmp, "c_SNA", Float64)
+    bs = gather(lmp, :c_SNA)
     return bs
 end
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -420,7 +420,7 @@ Base.@assume_effects :foldable function extract_global_datatype(name)
 end
 
 """
-    extract_atom(lmp::LMP, name::String; copy=false, with_ghosts=false)
+    extract_atom(lmp::LMP, name::Symbol; copy=false, with_ghosts=false)
 
 Extract per-atom data from the lammps instance.
 
@@ -563,7 +563,7 @@ function extract_compute(lmp::LMP, name::Symbol, style::_LMP_STYLE_CONST, lmp_ty
 end
 
 """
-    extract_variable(lmp::LMP, name::String, lmp_variable::LMP_VARIABLE, group::Union{Symbol, Nothing}=nothing; copy::Bool=false)
+    extract_variable(lmp::LMP, name::Symbol, lmp_variable::LMP_VARIABLE, group::Union{Symbol, Nothing}=nothing; copy::Bool=false)
 
 Extracts the data from a LAMMPS variable. When the variable is either an `equal`-style compatible variable,
 a `vector`-style variable, or an `atom`-style variable, the variable is evaluated and the corresponding value(s) returned.

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -849,7 +849,7 @@ row5 -> atom 4
 ```
 """
 function gather_impropers(lmp::LMP)
-    ndata = extract_global(lmp, :nimpropers)[]
+    ndata = extract_global(lmp, :nimpropers)
     data = Matrix{Int32}(undef, 5, ndata)
     API.lammps_gather_impropers(lmp, data)
     return data

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -365,7 +365,7 @@ end
 _is_2D_datatype(lmp_dtype::API._LMP_DATATYPE_CONST) = lmp_dtype in (API.LAMMPS_INT_2D, API.LAMMPS_DOUBLE_2D, API.LAMMPS_INT64_2D)
 
 """
-    extract_setting(lmp::LMP, name::String)::Int32
+    extract_setting(lmp::LMP, name::Symbol)::Int32
 
 Query LAMMPS about global settings.
 
@@ -391,7 +391,7 @@ function extract_setting(lmp::LMP, name::Symbol)::Int32
 end
 
 """
-    extract_global(lmp::LMP, name::String)
+    extract_global(lmp::LMP, name::Symbol)
 
 Extract a global property from a LAMMPS instance.
 A full list of global variables can be found in the [lammps documentation](https://docs.lammps.org/Library_properties.html).
@@ -423,7 +423,6 @@ end
     extract_atom(lmp::LMP, name::String; copy=false, with_ghosts=false)
 
 Extract per-atom data from the lammps instance.
-
 
 !!! info
     The returned data may become invalid if a re-neighboring operation

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -472,7 +472,7 @@ Base.@assume_effects :foldable function _extract_atom_datatype(name::Symbol)
     startswith(name_str, "d_") && return API.LAMMPS_DOUBLE
     startswith(name_str, "d2_") && return API.LAMMPS_DOUBLE_2D
 
-    # create a temporary lammps instance as lammps_extract_atom_datatype reqires a valid handle.
+    # create a temporary lammps instance as lammps_extract_atom_datatype requires a valid handle.
     # this unfortuately has the unavoidable side-effect of initializing MPI. However, as this
     # function is expected to be called only after another lammps instance has been created,
     # this shouldn't be a problem.

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -488,7 +488,7 @@ Base.@assume_effects :foldable function _extract_atom_datatype(name::Symbol)
 end
 
 """
-    extract_compute(lmp::LMP, name::String, style::_LMP_STYLE_CONST, lmp_type::_LMP_TYPE; copy::Bool=true)
+    extract_compute(lmp::LMP, name::Symbol, style::_LMP_STYLE_CONST, lmp_type::_LMP_TYPE; copy::Bool=true)
 
 Extract data provided by a compute command identified by the compute-ID.
 Computes may provide global, per-atom, or local data, and those may be a scalar, a vector or an array.

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -516,11 +516,11 @@ modify the internal state of the LAMMPS instance even if the data is scalar.
 
 ```julia
 LMP(["-screen", "none"]) do lmp
-    extract_compute(lmp, "thermo_temp", LMP_STYLE_GLOBAL, TYPE_VECTOR, copy=true)[2] = 2
-    extract_compute(lmp, "thermo_temp", LMP_STYLE_GLOBAL, TYPE_VECTOR, copy=false)[3] = 3
+    extract_compute(lmp, :thermo_temp, STYLE_GLOBAL, TYPE_VECTOR, copy=true)[2] = 2
+    extract_compute(lmp, :thermo_temp, STYLE_GLOBAL, TYPE_VECTOR, copy=false)[3] = 3
 
-    extract_compute(lmp, "thermo_temp", LMP_STYLE_GLOBAL, TYPE_SCALAR) |> println # [0.0]
-    extract_compute(lmp, "thermo_temp", LMP_STYLE_GLOBAL, TYPE_VECTOR) |> println # [0.0, 0.0, 3.0, 0.0, 0.0, 0.0]
+    extract_compute(lmp, :thermo_temp, STYLE_GLOBAL, TYPE_SCALAR) |> println # [0.0]
+    extract_compute(lmp, :thermo_temp, STYLE_GLOBAL, TYPE_VECTOR) |> println # [0.0, 0.0, 3.0, 0.0, 0.0, 0.0]
 end
 ```
 """
@@ -561,7 +561,7 @@ function extract_compute(lmp::LMP, name::Symbol, style::_LMP_STYLE_CONST, lmp_ty
 end
 
 """
-    extract_variable(lmp::LMP, name::String, lmp_variable::LMP_VARIABLE, group::Union{String, Nothing}=nothing; copy::Bool=false)
+    extract_variable(lmp::LMP, name::String, lmp_variable::LMP_VARIABLE, group::Union{Symbol, Nothing}=nothing; copy::Bool=false)
 
 Extracts the data from a LAMMPS variable. When the variable is either an `equal`-style compatible variable,
 a `vector`-style variable, or an `atom`-style variable, the variable is evaluated and the corresponding value(s) returned.
@@ -650,6 +650,7 @@ By default (when `ids=nothing`), this method collects data from all atoms in con
 The optional parameter `ids` determines for which subset of atoms the requested data will be gathered. The returned data will then be ordered according to `ids`
 
 Compute entities have the prefix `c_`, fix entities use the prefix `f_`, and per-atom entites have no prefix.
+`unwrap_image` only applies to `name=:image` and is ignored otherwise.
 
 The returned Array is decoupled from the internal state of the LAMMPS instance.
 
@@ -702,7 +703,7 @@ Base.@constprop :aggressive function gather(lmp::LMP, name::Symbol; ids::Union{N
 end
 
 """
-    scatter!(lmp::LMP, name::String, data::Array, ids::Union{Nothing, Array{Int32}}=nothing)
+    scatter!(lmp::LMP, name::Symbol, data::Array; ids::Union{Nothing, Array{Int32}}=nothing)
 
 Scatter the named per-atom, per-atom fix, per-atom compute, or fix property/atom-based entity in data to all processes.
 By default (when `ids=nothing`), this method scatters data to all atoms in consecutive order according to their IDs.
@@ -856,7 +857,7 @@ function gather_impropers(lmp::LMP)
 end
 
 """
-    group_to_atom_ids(lmp::LMP, group::String)
+    group_to_atom_ids(lmp::LMP, group::Symbol)
 
 Find the IDs of the Atoms in the group.
 """
@@ -884,7 +885,7 @@ end
 
 
 """
-    get_category_ids(lmp::LMP, category::String, buffer_size::Integer=50)
+    get_category_ids(lmp::LMP, category::Symbol, buffer_size::Integer=50)
 
 Look up the names of entities within a certain category.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,8 +31,10 @@ end
                 region cell block 0 1 0 2 0 3
                 create_box 1 cell
         """)
+        get_dt(lmp) = extract_global(lmp, :dt)
+        @inferred get_dt(lmp)
+        @test get_dt(lmp) isa Float64
 
-        @test extract_global(lmp, :dt) isa Float64
         @test extract_global(lmp, :boxhi) === (1.0, 2.0, 3.0)
         @test extract_global(lmp, :nlocal) == extract_setting(lmp, :nlocal) == 0
         @test_throws KeyError extract_global(lmp, :nonesense)
@@ -53,8 +55,9 @@ end
             mass 1 1
         """)
 
-        @test extract_atom(lmp, :mass) isa  Vector{Float64}
-        @test extract_atom(lmp, :mass) == [1]
+        get_mass(lmp) = extract_atom(lmp, :mass)
+        @inferred get_mass(lmp)
+        @test get_mass(lmp) == [1]
 
         x1 = extract_atom(lmp, :x) 
         @test size(x1) == (3, 27)
@@ -185,6 +188,9 @@ end
         scatter!(lmp, :f_pos, data_subset; ids=subset)
 
         @test gather(lmp, :x; ids=subset) == gather(lmp, :c_pos; ids=subset) == gather(lmp, :f_pos; ids=subset) == data_subset
+
+        gather_x(lmp) = gather(lmp, :x)
+        @inferred gather_x(lmp)
 
         # verify that no errors were missed
         @test LAMMPS.API.lammps_has_error(lmp) == 0


### PR DESCRIPTION
I managed to make `extract_atom`, `extract_global`, and `gather` typestable through constant propagation. These changes are unavoidably breaking, but I strongly believe that this is for the better.

I still have to update documentation and a few checks I probably also need to check that I haven't messed up anywhere but everything seems to be working at least.

I think we could also have a similar issue with cache invalidation as we have with BIGINT etc. But I'm not familiar enough with the internals of julia to know for sure.

I'd like to know your opinion on this @vchuravy
(P.s. I'm sorry for the large and messy PR)