### PR TITLE
Add support for Neighbor list information

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LAMMPS"
 uuid = "ee2e13b9-eee9-4449-aafa-cfa6a2dbe14d"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -986,9 +986,9 @@ struct NeighList <: AbstractVector{Pair{Int32, NeighListVec}}
 end
 
 function Base.getindex(nl::NeighList, element::Integer)
-    iatom = Ref{Int32}()
-    numneigh = Ref{Int32}()
-    neighbors = Ref{Ptr{Int32}}()
+    iatom = Ref{Cint}(-1)
+    numneigh = Ref{Cint}()
+    neighbors = Ref{Ptr{Cint}}()
     API.lammps_neighlist_element_neighbors(nl.lmp, nl.idx, element-1 #= 0-based indexing =#, iatom, numneigh, neighbors)
     iatom[] == -1 && throw(BoundsError(nl, element))
     return iatom[]+1 => NeighListVec(numneigh[], neighbors[])

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -996,7 +996,7 @@ The neighbor list request from a compute is identified by the compute ID and the
 The request ID is typically 0, but will be > 0 in case a compute has multiple neighbor list requests.
 
 Each neighbor list contains vectors of local indices of neighboring atoms.
-These can be used to index into Arrays returned form `extract_atom`.
+These can be used to index into Arrays returned from `extract_atom`.
 """
 function find_compute_neighlist(lmp::LMP, id::String; request=0)
     idx = API.lammps_find_compute_neighlist(lmp, id, request)
@@ -1013,7 +1013,7 @@ The neighbor list request from a fix is identified by the fix ID and the request
 The request ID is typically 0, but will be > 0 in case a fix has multiple neighbor list requests.
 
 Each neighbor list contains vectors of local indices of neighboring atoms.
-These can be used to index into Arrays returned form `extract_atom`.
+These can be used to index into Arrays returned from `extract_atom`.
 """
 function find_fix_neighlist(lmp::LMP, id::String; request=0)
     idx = API.lammps_find_compute_neighlist(lmp, id, request)
@@ -1032,7 +1032,7 @@ In that case nsub=0 will not produce a match and this function will Error.
 The final condition to be checked is the request ID (reqid). This will normally be 0, but some pair styles request multiple neighbor lists and set the request ID to a value > 0.
 
 Each neighbor list contains vectors of local indices of neighboring atoms.
-These can be used to index into Arrays returned form `extract_atom`.
+These can be used to index into Arrays returned from `extract_atom`.
 """
 function find_pair_neighlist(lmp::LMP, style::String; exact=false, nsub=0, request=0)
     idx = API.lammps_find_pair_neighlist(lmp, style, exact, nsub, request)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -963,7 +963,7 @@ struct NeighListVec <: AbstractVector{Int32}
 end
 
 function Base.getindex(nle::NeighListVec, i::Integer)
-    1 <= i <= nle.numneigh || throw(BoundsError(nle, i))
+    @boundscheck 1 <= i <= nle.numneigh || throw(BoundsError(nle, i))
     return unsafe_load(nle.neighbors, i)+1
 end
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -1031,6 +1031,35 @@ The final condition to be checked is the request ID (reqid). This will normally 
 
 Each neighbor list contains vectors of local indices of neighboring atoms.
 These can be used to index into Arrays returned from `extract_atom`.
+
+## Examples
+```julia
+lmp = LMP()
+
+command(lmp, \"""
+    region cell block 0 3 0 3 0 3
+    create_box 1 cell
+    lattice sc 1
+    create_atoms 1 region cell
+    mass 1 1
+
+    pair_style zero 1.0
+    pair_coeff * *
+
+    run 1
+\""")
+
+x = extract_atom(lmp, "x", LAMMPS_DOUBLE_2D; with_ghosts=true)
+
+for (iatom, neighs) in find_pair_neighlist(lmp, "zero")
+    for jatom in neighs
+        ix = @view x[:, iatom]
+        jx = @view x[:, jatom]
+
+        println(ix => jx)
+   end
+end
+```
 """
 function find_pair_neighlist(lmp::LMP, style::String; exact=false, nsub=0, request=0)
     idx = API.lammps_find_pair_neighlist(lmp, style, exact, nsub, request)

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -5,7 +5,7 @@ include("api.jl")
 export LMP, command, create_atoms, get_natoms, extract_atom, extract_compute, extract_global,
        extract_setting, gather, gather_bonds, gather_angles, gather_dihedrals, gather_impropers,
        scatter!, group_to_atom_ids, get_category_ids, extract_variable, LAMMPSError,
-       find_compute_neighlist, find_fix_neighlist, find_pair_neighlist,
+       compute_neighborlist, fix_neighborlist, pair_neighborlist,
 
        # _LMP_DATATYPE
        LAMMPS_NONE,
@@ -997,7 +997,7 @@ end
 Base.size(nl::NeighList) = (API.lammps_neighlist_num_elements(nl.lmp, nl.idx),)
 
 """
-    find_compute_neighlist(lmp::LMP, id::String; request=0)
+    compute_neighborlist(lmp::LMP, id::String; request=0)
 
 Find index of a neighbor list requested by a compute
 
@@ -1007,14 +1007,14 @@ The request ID is typically 0, but will be > 0 in case a compute has multiple ne
 Each neighbor list contains vectors of local indices of neighboring atoms.
 These can be used to index into Arrays returned from `extract_atom`.
 """
-function find_compute_neighlist(lmp::LMP, id::String; request=0)
+function compute_neighborlist(lmp::LMP, id::String; request=0)
     idx = API.lammps_find_compute_neighlist(lmp, id, request)
     idx == -1 && throw(KeyError(id))
     return NeighList(lmp, idx)
 end
 
 """
-    find_fix_neighlist(lmp::LMP, id::String; request=0)
+    fix_neighborlist(lmp::LMP, id::String; request=0)
 
 Find index of a neighbor list requested by a fix
 
@@ -1024,14 +1024,14 @@ The request ID is typically 0, but will be > 0 in case a fix has multiple neighb
 Each neighbor list contains vectors of local indices of neighboring atoms.
 These can be used to index into Arrays returned from `extract_atom`.
 """
-function find_fix_neighlist(lmp::LMP, id::String; request=0)
+function fix_neighborlist(lmp::LMP, id::String; request=0)
     idx = API.lammps_find_compute_neighlist(lmp, id, request)
     idx == -1 && throw(KeyError(id))
     return NeighList(lmp, idx)
 end
 
 """
-    find_pair_neighlist(lmp::LMP, style::String; exact=false, nsub=0, request=0)
+    pair_neighborlist(lmp::LMP, style::String; exact=false, nsub=0, request=0)
 
 This function determines which of the available neighbor lists for pair styles matches the given conditions. It first matches the style name. If exact is true the name must match exactly,
 if exact is false, a regular expression or sub-string match is done. If the pair style is hybrid or hybrid/overlay the style is matched against the sub styles instead.
@@ -1062,7 +1062,7 @@ command(lmp, \"""
 
 x = extract_atom(lmp, "x", LAMMPS_DOUBLE_2D; with_ghosts=true)
 
-for (iatom, neighs) in find_pair_neighlist(lmp, "zero")
+for (iatom, neighs) in pair_neighborlist(lmp, "zero")
     for jatom in neighs
         ix = @view x[:, iatom]
         jx = @view x[:, jatom]
@@ -1072,7 +1072,7 @@ for (iatom, neighs) in find_pair_neighlist(lmp, "zero")
 end
 ```
 """
-function find_pair_neighlist(lmp::LMP, style::String; exact=false, nsub=0, request=0)
+function pair_neighborlist(lmp::LMP, style::String; exact=false, nsub=0, request=0)
     idx = API.lammps_find_pair_neighlist(lmp, style, exact, nsub, request)
     idx == -1 && throw(KeyError(style))
     return NeighList(lmp, idx)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -369,12 +369,12 @@ end
             run 1
         """)
 
-        neighlist = find_pair_neighlist(lmp, "zero")
+        neighlist = pair_neighborlist(lmp, "zero")
         @test length(neighlist) == 27
         iatom, neihgs = neighlist[1]
         @test iatom == 1 # account for 1-based indexing
         @test length(neihgs) == 3
-        @test_throws KeyError find_pair_neighlist(lmp, "nonesense")
+        @test_throws KeyError pair_neighborlist(lmp, "nonesense")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -371,7 +371,9 @@ end
 
         neighlist = find_pair_neighlist(lmp, "zero")
         @test length(neighlist) == 27
-        @test length(neighlist[1]) == 4
+        iatom, neihgs = neighlist[1]
+        @test iatom == 1 # account for 1-based indexing
+        @test length(neihgs) == 3
         @test_throws KeyError find_pair_neighlist(lmp, "nonesense")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,4 +351,29 @@ end
     end
 end
 
+@testset "Neighbor lists" begin
+    LMP(["-screen", "none"]) do lmp
+        command(lmp, """
+            atom_modify map yes
+            region cell block 0 3 0 3 0 3
+            create_box 1 cell
+            lattice sc 1
+            create_atoms 1 region cell
+            mass 1 1
+
+            pair_style zero 1.0
+            pair_coeff * *
+
+            fix runfix all nve
+
+            run 1
+        """)
+
+        neighlist = find_pair_neighlist(lmp, "zero")
+        @test length(neighlist) == 27
+        @test length(neighlist[1]) == 4
+        @test_throws KeyError find_pair_neighlist(lmp, "nonesense")
+    end
+end
+
 @test success(pipeline(`$(MPI.mpiexec()) -n 2 $(Base.julia_cmd()) mpitest.jl`, stderr=stderr, stdout=stdout))


### PR DESCRIPTION
I took the liberty to pack each neighbor list entry into a single vector. I think that's easier to handle. Alternatively, we could also have each entry as a pair `ìatom => neighbors`.

Edit: Actually, I think it makes more sense to use Pairs. This makes looping over each neighbour of `iatom` way easier. This then also has a pretty clean syntax, because you can do `iatom, neighs = list[i]` and then loop over `neihgs`