### PR TITLE
Provide size_2d argument to extract_compute 

### DIFF
--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -541,7 +541,7 @@ function extract_atom_datatype(lmp::LMP, name)
 end
 
 """
-    extract_compute(lmp::LMP, name::String, style::_LMP_STYLE_CONST, lmp_type::_LMP_TYPE; copy::Bool=true)
+    extract_compute(lmp::LMP, name::String, style::_LMP_STYLE_CONST, lmp_type::_LMP_TYPE; copy::Bool=true, size_2d::Union{Tuple{Int64,Int64}, Nothing}=nothing)
 
 Extract data provided by a compute command identified by the compute-ID.
 Computes may provide global, per-atom, or local data, and those may be a scalar, a vector or an array.
@@ -564,6 +564,14 @@ Since computes may provide multiple kinds of data, it is required to set style a
 
 Scalar values get returned as a vector with a single element. This way it's possible to
 modify the internal state of the LAMMPS instance even if the data is scalar.
+
+The `size_2d` argument allows users to pre-specify the size of the 2D array when `style=STYLE_GLOBAL` 
+and `lmp_type=TYPE_ARRAY`, thus bypassing the need to perform multiple extracts to determine row and column size. 
+
+!!! warning
+    The `size_2d` option is fundamentally memory-unsafe and will lead to out-of-bounds access if the specified 
+    size is larger than the array returned by the LAMMPS instance. It should only be used if the user confidently 
+    knows what size the returned 2D array will be. Otherwise, do not use this keyword argument!
 
 !!! info
     The returned data may become invalid as soon as another LAMMPS command has been issued at any point after calling this method.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -267,6 +267,29 @@ end
     end
 end
 
+@testset "Extract Compute Global Array" begin
+    LMP(["-screen", "none"]) do lmp
+        command(lmp, """
+            atom_modify map yes
+            region cell block 0 6 0 6 0 6
+            create_box 1 cell
+            lattice sc 1
+            create_atoms 1 region cell
+            mass 1 1
+
+            compute bin3d all chunk/atom bin/3d x lower 3.0 y lower 3.0 z lower 3.0 compress yes units box
+            compute prop3 all property/chunk bin3d id count
+        """)
+
+        prop_arr1 = extract_compute(lmp, "prop3", STYLE_GLOBAL, TYPE_ARRAY)
+        @test size(prop_arr1) == (2,8)
+
+        prop_arr2 = extract_compute(lmp, "prop3", STYLE_GLOBAL, TYPE_ARRAY; size_2d=(2,8))
+        @test prop_arr1 == prop_arr2
+    end
+end
+
+
 @testset "Utilities" begin
     LMP(["-screen", "none"]) do lmp
         # setting up example data


### PR DESCRIPTION
For global style computes that return an array, this keyword allows you to pre-specify the size of the array and skip the extra `extract_compute` calls to get `SIZE_ROWS` and `SIZE_COLS`. 

The context  for this is that I've been developing an interface to the POD potential in LAMMPS (see [this PR](https://github.com/cesmix-mit/InteratomicPotentials.jl/pull/53) ), which involves extracting from the `pod/global` compute. This is a very expensive compute, and the current version of `extract_compute` repeats it two additional times to get the row and column size, which makes things much slower on my end. I know the exact size of this array in advance, so having this keyword argument allows me to greatly increase performance. 

Obviously, this is a very unsafe option, and I've tried to indicate this in the documentation. 
