### PR TITLE
Use `extract_atom_size` to determine size of per-atom data

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 CEnum = "0.4, 0.5"
-LAMMPS_jll = "2.6.0"
+LAMMPS_jll = "2.8.0"
 MPI = "0.20"
 Preferences = "1"
 julia = "1.10"

--- a/res/Manifest.toml
+++ b/res/Manifest.toml
@@ -1,220 +1,256 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[ArgTools]]
+julia_version = "1.11.5"
+manifest_format = "2.0"
+project_hash = "29c5f725f1b78296de914398e5edb4af5ec639ba"
+
+[[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
+version = "1.1.2"
 
-[[Artifacts]]
+[[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
-[[Base64]]
+[[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
-[[CEnum]]
+[[deps.CEnum]]
 git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 version = "0.5.0"
 
-[[Clang]]
+[[deps.CUDA_Driver_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f69205592dbd3721a156245b6dd837206786a848"
+uuid = "4ee394cb-3365-5eb0-8335-949819d2adfc"
+version = "0.12.1+1"
+
+[[deps.CUDA_Runtime_jll]]
+deps = ["Artifacts", "CUDA_Driver_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "99f1c6b659c14bbb3492246791bb4928a40ceb84"
+uuid = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
+version = "0.16.1+0"
+
+[[deps.Clang]]
 deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
-git-tree-sha1 = "aa03729cc19fc581d21b33c7b4a1bab5c96f6345"
-repo-rev = "master"
-repo-url = "https://github.com/JuliaInterop/Clang.jl.git"
+git-tree-sha1 = "2397d5da17ba4970f772a9888b208a0a1d77eb5d"
 uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 version = "0.18.3"
 
-[[Clang_jll]]
+[[deps.Clang_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "TOML", "Zlib_jll", "libLLVM_jll"]
-git-tree-sha1 = "de2204d98741f57e7ddb9a6a738db74ba8a608cb"
+git-tree-sha1 = "ebfc8e89823ec2c85ed9fedabe52db149da4c5ec"
 uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
-version = "15.0.7+10"
+version = "16.0.6+5"
 
-[[CompilerSupportLibraries_jll]]
+[[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.1.1+0"
 
-[[Dates]]
+[[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
-[[Downloads]]
+[[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.6.0"
 
-[[FileWatching]]
-uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
-
-[[Hwloc_jll]]
+[[deps.FFTW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "5e19e1e4fa3e71b774ce746274364aef0234634e"
+git-tree-sha1 = "6d6219a004b8cf1e0b4dbe27a2860b8e04eba0be"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.11+0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.Hwloc_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "f93a9ce66cd89c9ba7a4695a47fd93b4c6bc59fa"
 uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
-version = "2.11.1+0"
+version = "2.12.0+0"
 
-[[InteractiveUtils]]
-deps = ["Markdown"]
-uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
-[[JLLWrappers]]
+[[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "f389674c99bfcde17dc57454011aa44d5a260a40"
+git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.6.0"
+version = "1.7.0"
 
-[[LAMMPS_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML"]
-git-tree-sha1 = "088be028d89853390a3f4eaf36d459a78ac843e5"
+[[deps.LAMMPS_jll]]
+deps = ["Artifacts", "CUDA_Driver_jll", "CUDA_Runtime_jll", "CompilerSupportLibraries_jll", "FFTW_jll", "JLLWrappers", "LLVMOpenMP_jll", "LazyArtifacts", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "libblastrampoline_jll"]
+git-tree-sha1 = "1131a79f5bd429e878285c305e685c702ab744ad"
 uuid = "5b3ab26d-9607-527c-88ea-8fe5ba57cafe"
-version = "2.6.0+0"
+version = "2.8.0+0"
 
-[[LazyArtifacts]]
+[[deps.LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "78211fb6cbc872f77cad3fc0b6cf647d923f4929"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "18.1.7+0"
+
+[[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
 uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
 
-[[LibCURL]]
+[[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
-[[LibCURL_jll]]
+[[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.4.0+0"
+version = "8.6.0+0"
 
-[[LibGit2]]
+[[deps.LibGit2]]
 deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
 
-[[LibGit2_jll]]
+[[deps.LibGit2_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.6.4+0"
+version = "1.7.2+0"
 
-[[LibSSH2_jll]]
+[[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 version = "1.11.0+1"
 
-[[Libdl]]
+[[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
-[[Logging]]
+[[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
-[[MPICH_jll]]
+[[deps.MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "19d4bd098928a3263693991500d05d74dbdc2004"
+git-tree-sha1 = "3aa3210044138a1749dbd350a9ba8680869eb503"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "4.2.2+0"
+version = "4.3.0+1"
 
-[[MPIPreferences]]
+[[deps.MPIPreferences]]
 deps = ["Libdl", "Preferences"]
 git-tree-sha1 = "c105fe467859e7f6e9a852cb15cb4301126fac07"
 uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 version = "0.1.11"
 
-[[MPItrampoline_jll]]
+[[deps.MPItrampoline_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "8c35d5420193841b2f367e658540e8d9e0601ed0"
+git-tree-sha1 = "ff91ca13c7c472cef700f301c8d752bc2aaff1a8"
 uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
-version = "5.4.0+0"
+version = "5.5.3+0"
 
-[[Markdown]]
+[[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
-[[MbedTLS_jll]]
+[[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
+version = "2.28.6+0"
 
-[[MicrosoftMPI_jll]]
+[[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "f12a29c4400ba812841c6ace3f4efbb6dbb3ba01"
+git-tree-sha1 = "bc95bf4149bf535c09602e3acdf950d9b4376227"
 uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
-version = "10.1.4+2"
+version = "10.1.4+3"
 
-[[MozillaCACerts_jll]]
+[[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2023.12.12"
 
-[[NetworkOptions]]
+[[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
-[[OpenMPI_jll]]
+[[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]
-git-tree-sha1 = "bfce6d523861a6c562721b262c0d1aaeead2647f"
+git-tree-sha1 = "047b66eb62f3cae59ed260ebb9075a32a04350f1"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "5.0.5+0"
+version = "5.0.7+2"
 
-[[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.10.0"
+version = "1.11.0"
 
-[[Preferences]]
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+    [deps.Pkg.weakdeps]
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Preferences]]
 deps = ["TOML"]
 git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 version = "1.4.3"
 
-[[Printf]]
+[[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
-[[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
-uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-
-[[Random]]
+[[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
-[[SHA]]
+[[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
-[[Serialization]]
-uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
-[[Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
-[[TOML]]
+[[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 version = "1.0.3"
 
-[[Tar]]
+[[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
 
-[[UUIDs]]
+[[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
-[[Unicode]]
+[[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
-[[Zlib_jll]]
+[[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.2.13+1"
 
-[[libLLVM_jll]]
+[[deps.libLLVM_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
-version = "15.0.7+10"
+version = "16.0.6+5"
 
-[[nghttp2_jll]]
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"
+
+[[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.52.0+1"
+version = "1.59.0+0"
 
-[[p7zip_jll]]
+[[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 version = "17.4.0+2"

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -514,7 +514,7 @@ A table with suported name keywords can be found in the [lammps documentation](h
 
 ## Arguments
 - `copy`: determines whether lammps internal memory is used or if a copy is made.
-- `with_ghosts`: Determines wheter entries for ghost atoms are included. This is ignored for "mass".
+- `with_ghosts`: Determines wheter entries for ghost atoms are included. This is ignored for "mass", or when there is no ghost atom data available.
 """
 function extract_atom(lmp::LMP, name::String, lmp_type::_LMP_DATATYPE; copy=false, with_ghosts=false)
     void_ptr = API.lammps_extract_atom(lmp, name)
@@ -532,13 +532,14 @@ function extract_atom(lmp::LMP, name::String, lmp_type::_LMP_DATATYPE; copy=fals
         return _extract(ptr, length; copy=copy)
     end
 
-    length = extract_setting(lmp, with_ghosts ? "nall" : "nlocal")
+    length = if with_ghosts
+        API.lammps_extract_atom_size(lmp, name, API.LMP_SIZE_ROWS)
+    else
+        extract_setting(lmp, "nlocal")
+    end
 
     if _is_2D_datatype(lmp_type)
-        # only Quaternions have 4 entries
-        # length is a Int32 and lammps_wrap expects a NTuple, so it's
-        # neccecary to use Int32 for count as well
-        count = name == "quat" ? Int32(4) : Int32(3)
+        count = API.lammps_extract_atom_size(lmp, name, API.LMP_SIZE_COLS)
         return _extract(ptr, (count, length); copy=copy)
     end
 
@@ -805,11 +806,9 @@ function _get_count(lmp::LMP, name::String)
     if startswith(name, r"[f,c]_")
         if name[1] == 'c'
             API.lammps_has_id(lmp, "compute", name[3:end]) != 1 && error("Unknown per atom compute $name")
-
             count_ptr = API.lammps_extract_compute(lmp::LMP, name[3:end], API.LMP_STYLE_ATOM, API.LMP_SIZE_COLS)
         else
             API.lammps_has_id(lmp, "fix", name[3:end]) != 1 && error("Unknown per atom fix $name")
-
             count_ptr = API.lammps_extract_fix(lmp::LMP, name[3:end], API.LMP_STYLE_ATOM, API.LMP_SIZE_COLS, 0, 0)
         end
         check(lmp)
@@ -818,15 +817,15 @@ function _get_count(lmp::LMP, name::String)
         count = unsafe_load(count_ptr)
     
         # a count of 0 indicates that the entity is a vector. In order to perserve type stability we just treat that as a 1xN Matrix.
-        return count == 0 ? 1 : count
-    elseif name in ("mass", "id", "type", "mask", "image", "molecule", "q", "radius", "rmass", "ellipsoid", "line", "tri", "body", "temperature", "heatflow")
-        return 1
-    elseif name in ("x", "v", "f", "mu", "omega", "angmom", "torque")
-        return 3
-    elseif name == "quat"
-        return 4
+        return count == 0 ? Cint(1) : count
     else
-        error("Unknown per atom property $name")
+        type = API.lammps_extract_atom_datatype(lmp, name)
+        type == -1 && error("Unknown per-atom property $name")
+        if type in (API.LAMMPS_INT_2D, API.LAMMPS_DOUBLE_2D, API.LAMMPS_INT64_2D)
+            API.lammps_extract_atom_size(lmp, name, API.LMP_SIZE_COLS)
+        else
+            return Cint(1)
+        end
     end
 end
 

--- a/src/LAMMPS.jl
+++ b/src/LAMMPS.jl
@@ -187,6 +187,12 @@ mutable struct LMP
 
         this = new(handle)
         finalizer(close!, this)
+
+        ver = version(this)
+        if ver < 20250402 
+            loaded = string(ver)[1:4] * '-' * string(ver)[5:6] * '-' * string(ver)[7:8]
+            error("This version of LAMMPS.jl is only compatible with lammps version 2025-04-02 or newer.\nThe currently loaded version of lammps is $loaded")
+        end
         return this
     end
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -87,6 +87,10 @@ function lammps_error(handle, error_type, error_text)
     ccall((:lammps_error, liblammps), Cvoid, (Ptr{Cvoid}, Cint, Ptr{Cchar}), handle, error_type, error_text)
 end
 
+function lammps_expand(handle, line)
+    ccall((:lammps_expand, liblammps), Ptr{Cchar}, (Ptr{Cvoid}, Ptr{Cchar}), handle, line)
+end
+
 function lammps_file(handle, file)
     ccall((:lammps_file, liblammps), Cvoid, (Ptr{Cvoid}, Ptr{Cchar}), handle, file)
 end
@@ -159,6 +163,10 @@ function lammps_extract_atom_datatype(handle, name)
     ccall((:lammps_extract_atom_datatype, liblammps), Cint, (Ptr{Cvoid}, Ptr{Cchar}), handle, name)
 end
 
+function lammps_extract_atom_size(handle, name, type)
+    ccall((:lammps_extract_atom_size, liblammps), Cint, (Ptr{Cvoid}, Ptr{Cchar}, Cint), handle, name, type)
+end
+
 function lammps_extract_atom(handle, name)
     ccall((:lammps_extract_atom, liblammps), Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cchar}), handle, name)
 end
@@ -193,6 +201,22 @@ end
 
 function lammps_variable_info(handle, idx, buf, bufsize)
     ccall((:lammps_variable_info, liblammps), Cint, (Ptr{Cvoid}, Cint, Ptr{Cchar}, Cint), handle, idx, buf, bufsize)
+end
+
+function lammps_eval(handle, expr)
+    ccall((:lammps_eval, liblammps), Cdouble, (Ptr{Cvoid}, Ptr{Cchar}), handle, expr)
+end
+
+function lammps_clearstep_compute(handle)
+    ccall((:lammps_clearstep_compute, liblammps), Cvoid, (Ptr{Cvoid},), handle)
+end
+
+function lammps_addstep_compute_all(handle, nextstep)
+    ccall((:lammps_addstep_compute_all, liblammps), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), handle, nextstep)
+end
+
+function lammps_addstep_compute(handle, nextstep)
+    ccall((:lammps_addstep_compute, liblammps), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), handle, nextstep)
 end
 
 function lammps_gather_atoms(handle, name, type, count, data)
@@ -283,37 +307,37 @@ function lammps_get_os_info(buffer, buf_size)
     ccall((:lammps_get_os_info, liblammps), Cvoid, (Ptr{Cchar}, Cint), buffer, buf_size)
 end
 
-# no prototype is found for this function at library.h:241:5, please use with caution
+# no prototype is found for this function at library.h:249:5, please use with caution
 function lammps_config_has_mpi_support()
     ccall((:lammps_config_has_mpi_support, liblammps), Cint, ())
 end
 
-# no prototype is found for this function at library.h:242:5, please use with caution
+# no prototype is found for this function at library.h:250:5, please use with caution
 function lammps_config_has_gzip_support()
     ccall((:lammps_config_has_gzip_support, liblammps), Cint, ())
 end
 
-# no prototype is found for this function at library.h:243:5, please use with caution
+# no prototype is found for this function at library.h:251:5, please use with caution
 function lammps_config_has_png_support()
     ccall((:lammps_config_has_png_support, liblammps), Cint, ())
 end
 
-# no prototype is found for this function at library.h:244:5, please use with caution
+# no prototype is found for this function at library.h:252:5, please use with caution
 function lammps_config_has_jpeg_support()
     ccall((:lammps_config_has_jpeg_support, liblammps), Cint, ())
 end
 
-# no prototype is found for this function at library.h:245:5, please use with caution
+# no prototype is found for this function at library.h:253:5, please use with caution
 function lammps_config_has_ffmpeg_support()
     ccall((:lammps_config_has_ffmpeg_support, liblammps), Cint, ())
 end
 
-# no prototype is found for this function at library.h:246:5, please use with caution
+# no prototype is found for this function at library.h:254:5, please use with caution
 function lammps_config_has_curl_support()
     ccall((:lammps_config_has_curl_support, liblammps), Cint, ())
 end
 
-# no prototype is found for this function at library.h:247:5, please use with caution
+# no prototype is found for this function at library.h:255:5, please use with caution
 function lammps_config_has_exceptions()
     ccall((:lammps_config_has_exceptions, liblammps), Cint, ())
 end
@@ -322,7 +346,7 @@ function lammps_config_has_package(arg1)
     ccall((:lammps_config_has_package, liblammps), Cint, (Ptr{Cchar},), arg1)
 end
 
-# no prototype is found for this function at library.h:250:5, please use with caution
+# no prototype is found for this function at library.h:258:5, please use with caution
 function lammps_config_package_count()
     ccall((:lammps_config_package_count, liblammps), Cint, ())
 end
@@ -335,7 +359,7 @@ function lammps_config_accelerator(arg1, arg2, arg3)
     ccall((:lammps_config_accelerator, liblammps), Cint, (Ptr{Cchar}, Ptr{Cchar}, Ptr{Cchar}), arg1, arg2, arg3)
 end
 
-# no prototype is found for this function at library.h:254:5, please use with caution
+# no prototype is found for this function at library.h:262:5, please use with caution
 function lammps_has_gpu_device()
     ccall((:lammps_has_gpu_device, liblammps), Cint, ())
 end
@@ -368,7 +392,7 @@ function lammps_id_name(arg1, arg2, arg3, arg4, arg5)
     ccall((:lammps_id_name, liblammps), Cint, (Ptr{Cvoid}, Ptr{Cchar}, Cint, Ptr{Cchar}, Cint), arg1, arg2, arg3, arg4, arg5)
 end
 
-# no prototype is found for this function at library.h:265:5, please use with caution
+# no prototype is found for this function at library.h:273:5, please use with caution
 function lammps_plugin_count()
     ccall((:lammps_plugin_count, liblammps), Cint, ())
 end
@@ -444,7 +468,11 @@ function lammps_get_last_error_message(handle, buffer, buf_size)
     ccall((:lammps_get_last_error_message, liblammps), Cint, (Ptr{Cvoid}, Ptr{Cchar}, Cint), handle, buffer, buf_size)
 end
 
-# no prototype is found for this function at library.h:308:5, please use with caution
+function lammps_set_show_error(handle, flag)
+    ccall((:lammps_set_show_error, liblammps), Cint, (Ptr{Cvoid}, Cint), handle, flag)
+end
+
+# no prototype is found for this function at library.h:315:5, please use with caution
 function lammps_python_api_version()
     ccall((:lammps_python_api_version, liblammps), Cint, ())
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,6 +351,40 @@ end
     end
 end
 
+@testset "Custom Properties" begin
+    LMP(["-screen", "none"]) do lmp
+        command(lmp, """
+            atom_modify map yes
+            region cell block 0 3 0 3 0 3
+            create_box 1 cell
+            lattice sc 1
+            create_atoms 1 region cell
+            mass 1 1
+
+            fix customprop all property/atom i_int i2_int2 5 d_float d2_float2 6
+        """)
+
+        i_int = extract_atom(lmp, "i_int", LAMMPS_INT)
+        @test size(i_int) == (27,)
+        @test all(iszero, i_int)
+
+        i2_int2 = extract_atom(lmp, "i2_int2", LAMMPS_INT_2D)
+        @test size(i2_int2) == (5, 27)
+        @test all(iszero, i2_int2)
+
+        d_float = extract_atom(lmp, "d_float", LAMMPS_DOUBLE)
+        @test size(d_float) == (27,)
+        @test all(iszero, d_float)
+
+        d2_float2 = extract_atom(lmp, "d2_float2", LAMMPS_DOUBLE_2D)
+        @test size(d2_float2) == (6, 27)
+        @test all(iszero, d2_float2)
+
+        # verify that no errors were missed
+        @test LAMMPS.API.lammps_has_error(lmp) == 0
+    end
+end
+
 if !Sys.iswindows()
     @testset "MPI" begin
          @test success(pipeline(`$(MPI.mpiexec()) -n 2 $(Base.julia_cmd()) mpitest.jl`, stderr=stderr, stdout=stdout))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,8 +259,8 @@ end
         @test extract_compute(lmp, "thermo_temp", STYLE_GLOBAL, TYPE_SCALAR) == [0.0]
         @test extract_compute(lmp, "thermo_temp", STYLE_GLOBAL, TYPE_VECTOR) == [0.0, 0.0, 3.0, 0.0, 0.0, 0.0]
 
-        @test_throws ErrorException extract_compute(lmp, "thermo_temp", STYLE_ATOM, TYPE_SCALAR)
-        @test_throws ErrorException extract_compute(lmp, "thermo_temp", STYLE_GLOBAL, TYPE_ARRAY)
+        @test_throws LAMMPSError extract_compute(lmp, "thermo_temp", STYLE_ATOM, TYPE_SCALAR)
+        @test_throws LAMMPSError extract_compute(lmp, "thermo_temp", STYLE_GLOBAL, TYPE_ARRAY)
 
         # verify that no errors were missed
         @test LAMMPS.API.lammps_has_error(lmp) == 0


### PR DESCRIPTION
I've updated `extract_atom` and the `gather/scatter` methods to use `extract_atom_size` instead of hardcoding the number of entries for each per-atom property. This makes it possible to use custom properties with the [fix property/atom command](https://docs.lammps.org/fix_property_atom.html#fix-property-atom-command).

As `extract_atom_size` has only been introduced in Lammps 2 Apr 2025, LAMMPS.jl is no longer compatible with older lammps versions.

Some of the error handling in LAMMPS has changes as well. I've made adjustments where necessary.