### PR TITLE
Implement system to pass global and per-atom properties to compute_potential

### DIFF
--- a/src/external.jl
+++ b/src/external.jl
@@ -97,16 +97,137 @@ function set_energy_peratom(fix::FixExternal, energy; set_global=false)
     check(fix.lmp)
 end
 
+function _check_atom_datatype(lmp, name, T)
+    lammps_type = API.lammps_extract_atom_datatype(lmp, name)
+    rows::Int = API.lammps_extract_atom_size(lmp, name, API.LMP_SIZE_COLS)
+
+    if lammps_type == API.LAMMPS_INT64
+        T !== Int64 && throw(ArgumentError("Expected type Int64 for per-atom property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_INT
+        T !== Int32 && throw(ArgumentError("Expected type Int32 for per-atom property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_DOUBLE
+        T !== Float64 && throw(ArgumentError("Expected type Float64 for per-atom property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_INT64_2D
+        (T !== NTuple{rows, Int64} && T !== SVector{rows, Int64}) && throw(ArgumentError("Expected type NTuple{$rows, Int64} or SVector{$rows, Int64} for per-atom property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_INT_2D
+        (T !== NTuple{rows, Int32} && T !== SVector{rows, Int32}) && throw(ArgumentError("Expected type NTuple{$rows, Int32} or SVector{$rows, Int32} for per-atom property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_DOUBLE_2D
+        (T !== NTuple{rows, Float64} && T !== SVector{rows, Float64}) && throw(ArgumentError("Expected type NTuple{$rows, Float64} or SVector{$rows, Float64} for per-atom property :$name, got $T instead"))
+    else
+        throw(KeyError(name))
+    end
+end
+
+function _check_atom_ghost(lmp, name, nall)
+    cols = API.lammps_extract_atom_size(lmp, name, API.LMP_SIZE_ROWS)
+    cols == nall || throw(ArgumentError("Per-atom property :$name doesn't communicate ghost data"))
+    nothing
+end
+
+struct ExtractAtomMultiple{T<:NamedTuple, P} <: AbstractVector{T}
+    ptrs::P
+    length::Int
+    
+    function ExtractAtomMultiple{T}(lmp) where T
+        nall = extract_setting(lmp, "nall")
+        ptrs = map(fieldnames(T)) do name
+            Base.@constprop :aggressive
+            type = fieldtype(T, name)
+            void_ptr = API.lammps_extract_atom(lmp, name)
+            void_ptr == C_NULL && throw(KeyError(name))
+            API.lammps_extract_atom_size(lmp, name, API.LMP_SIZE_ROWS)
+            _check_atom_datatype(lmp, name, type)
+            _check_atom_ghost(lmp, name, nall)
+            if name === :mass
+                type_ptr::Ptr{Int32} = API.lammps_extract_atom(lmp, :type)
+                ntypes = extract_setting(lmp, "ntypes")
+                (type_ptr, Ptr{type}(void_ptr))
+            elseif type<:Real
+                Ptr{type}(void_ptr)
+            elseif nall == 0
+                Ptr{type}(C_NULL)
+            else
+                unsafe_load(Ptr{Ptr{type}}(void_ptr))
+            end
+        end |> NamedTuple{fieldnames(T)}
+        return new{T, typeof(ptrs)}(ptrs, nall)
+    end
+end
+
+Base.size(self::ExtractAtomMultiple) = (self.length,)
+function Base.getindex(self::ExtractAtomMultiple{T}, i::Integer) where T
+    @boundscheck checkbounds(self, i)
+    map(self.ptrs) do ptr
+        if ptr isa Tuple
+            type = unsafe_load(ptr[1])
+            return unsafe_load(ptr[2], type+1)
+        end
+        unsafe_load(ptr, i)
+    end
+end
+
+function _check_global_datatype(lmp, name, T)
+    lammps_type = API.lammps_extract_global_datatype(lmp, name)
+
+    if name in (:sublo, :subhi, :sublo_lambda, :subhi_lambda)
+        (T !== NTuple{3, Float64} && T !== SVector{3, Float64}) && throw(ArgumentError("Expected type NTuple{3, Float64} or SVector{3, Float64} for global property :$name, got $T instead"))
+    elseif name == :procgrid
+        (T !== NTuple{3, Int32} && T !== SVector{3, Int32}) && throw(ArgumentError("Expected type NTuple{3, Int32} or SVector{3, Int32} for global property :$name, got $T instead"))
+    elseif name in (:special_lj, :special_coul)
+        (T !== NTuple{4, Float64} && T !== SVector{4, Float64}) && throw(ArgumentError("Expected type NTuple{4, Float64} or SVector{4, Float64} for global property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_INT64
+        T !== Int64 && throw(ArgumentError("Expected type Int64 for global property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_INT
+        T !== Int32 && throw(ArgumentError("Expected type Int32 for global property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_DOUBLE
+        T !== Float64 && throw(ArgumentError("Expected type Float64 for global property :$name, got $T instead"))
+    elseif lammps_type == API.LAMMPS_STRING
+        T !== String && throw(ArgumentError("Expected type String for global property :$name, got $T instead"))
+    else
+        throw(KeyError(name))
+    end
+end
+
+struct ExtractGlobalMultiple{T<:NamedTuple, P}
+    ptrs::P
+
+    function ExtractGlobalMultiple{T}(lmp) where T
+        ptrs = map(fieldnames(T)) do name
+            Base.@constprop :aggressive
+            type = fieldtype(T, name)
+            void_ptr = API.lammps_extract_global(lmp, name)
+            void_ptr == C_NULL && throw(KeyError(name))
+            _check_global_datatype(lmp, name, type)
+            if type === String
+                Ptr{Cchar}(void_ptr)
+            else
+                Ptr{type}(void_ptr)
+            end
+        end |> NamedTuple{fieldnames(T)}
+        return new{T, typeof(ptrs)}(ptrs)
+    end
+end
+
+function Base.getindex(self::ExtractGlobalMultiple)
+    map(self.ptrs) do ptr
+        ptr isa Ptr{Cchar} && return unsafe_storing(ptr)
+        return unsafe_load(ptr)
+    end
+end
+
 _dott(v) = SA[v.x*v.x, v.y*v.y, v.z*v.z, v.x*v.y, v.x*v.z, v.y*v.z]
 
-function PairExternal(compute_potential::F, lmp::LMP, name::String, cutoff::Float64; backend::Union{Nothing, AbstractADType} = nothing) where F
+function PairExternal(compute_potential::F, lmp::LMP, name::String, system_properties::Type{T}, atom_properties::Type{U}, cutoff::Float64; backend::Union{Nothing, AbstractADType} = nothing) where {F, T<:NamedTuple, U<:NamedTuple}
     command(lmp, """
         pair_style zero $cutoff nocoeff full
         pair_coeff * *
     """)
 
+    system_ptrs = ExtractGlobalMultiple{system_properties}(lmp) # persistent in memory
+
     FixExternal(lmp, name, "all", 1, 1) do fix::FixExternal
-        type = LAMMPS.extract_atom(fix.lmp, "type", LAMMPS_INT; with_ghosts=true)
+        system = system_ptrs[]
+        atom = ExtractAtomMultiple{atom_properties}(lmp)
         x = reinterpret(reshape, SVector{3, Float64}, fix.x)
         force = reinterpret(reshape, SVector{3, Float64}, fix.f)
 
@@ -114,24 +235,24 @@ function PairExternal(compute_potential::F, lmp::LMP, name::String, cutoff::Floa
             energy = @alloc(Float64, fix.nlocal)
             virial = @alloc(SVector{6, Float64}, fix.nlocal)
 
-            @inbounds for (iatom, neigh) in pair_neighborlist(fix.lmp, "zero")
+            @inbounds for (i, neigh) in pair_neighborlist(fix.lmp, "zero")
                 ienergy = 0.
                 iforce = zero(SVector{3, Float64})
                 ivirial = zero(SVector{6, Float64})
 
-                itype = type[iatom]
-                ipos = x[iatom]
+                iatom = atom[i]
+                ipos = x[i]
 
-                for jatom in neigh
-                    jtype = type[jatom]
-                    diff = ipos - x[jatom]
+                for j in neigh
+                    jatom = atom[j]
+                    diff = ipos - x[j]
                     r = norm(diff)
                     r > cutoff && continue
 
                     if backend === nothing
-                        _energy, _force,  = compute_potential(r, itype, jtype)
+                        _energy, _force,  = compute_potential(r, system, iatom, jatom)
                     else
-                        _energy, _derivative = value_and_derivative(compute_potential, backend, r, Constant(itype), Constant(jtype))
+                        _energy, _derivative = value_and_derivative(compute_potential, backend, r, Constant(system), Constant(iatom), Constant(jatom))
                         _force = -_derivative
                     end
 
@@ -140,9 +261,9 @@ function PairExternal(compute_potential::F, lmp::LMP, name::String, cutoff::Floa
                     ivirial += (0.5 * _force / r) * _dott(diff)
                 end
 
-                energy[iatom] = ienergy
-                force[iatom] = iforce
-                virial[iatom] = ivirial
+                energy[i] = ienergy
+                force[i] = iforce
+                virial[i] = ivirial
             end
 
             set_energy_peratom(fix, energy; set_global=true)

--- a/test/external_pair.jl
+++ b/test/external_pair.jl
@@ -10,8 +10,7 @@ const coefficients = Base.ImmutableDict(
     )
 )
 
-
-@testset "external_pair" begin
+@testset "external_pair_lj" begin
     for units in ("lj", "si"),  backend in (nothing, AutoForwardDiff(), AutoEnzyme())
         lmp_native = LMP(["-screen", "none"])
         lmp_julia = LMP(["-screen", "none"])
@@ -34,8 +33,10 @@ const coefficients = Base.ImmutableDict(
         command(lmp_native, "pair_coeff * * 1 1")
 
         # Register external fix
-        lj = LAMMPS.PairExternal(lmp_julia, "julia_lj", cutoff; backend) do r, itype, jtype
-            ε, σ = coefficients[itype][jtype]
+        system_properties = @NamedTuple{}
+        atom_properties = @NamedTuple{type::Int32}
+        lj = LAMMPS.PairExternal(lmp_julia, "julia_lj", system_properties, atom_properties, cutoff; backend) do r, system, iatom, jatom
+            ε, σ = coefficients[iatom.type][jatom.type]
             r6inv  = (σ/r)^6
             energy = 4ε * (r6inv * (r6inv - 1))
             force = 24ε * (r6inv * (2r6inv - 1)) / r
@@ -53,6 +54,85 @@ const coefficients = Base.ImmutableDict(
                 compute virial all stress/atom NULL
                 compute virial_tot all pressure thermo_temp
             """)
+
+            scatter!(lmp, "x", positions)
+
+            command(lmp, "run 0")
+        end
+
+        # extract forces
+        potential_native = gather(lmp_native, "c_potential", Float64)
+        potential_julia = gather(lmp_julia, "c_potential", Float64)
+        forces_native = gather(lmp_native, "f", Float64)
+        forces_julia = gather(lmp_julia, "f", Float64)
+        virial_native = gather(lmp_native, "c_virial", Float64)
+        virial_julia = gather(lmp_julia, "c_virial", Float64)
+        virial_tot_native = extract_compute(lmp_native, "virial_tot", STYLE_GLOBAL, TYPE_VECTOR)
+        virial_tot_julia = extract_compute(lmp_julia, "virial_tot", STYLE_GLOBAL, TYPE_VECTOR)
+        energy_native = LAMMPS.API.lammps_get_thermo(lmp_native, "etotal")
+        energy_julia = LAMMPS.API.lammps_get_thermo(lmp_julia, "etotal")
+
+        @testset "$units $backend" begin
+            @test potential_native ≈ potential_julia
+            @test forces_native ≈ forces_julia
+            @test virial_native ≈ virial_julia
+            @test virial_tot_native ≈ virial_tot_julia
+            @test energy_native ≈ energy_julia
+        end
+    end
+end
+
+@testset "external_pair_coul" begin
+    for units in ("lj", "si"),  backend in (nothing, AutoForwardDiff(), AutoEnzyme())
+        lmp_native = LMP(["-screen", "none"])
+        lmp_julia = LMP(["-screen", "none"])
+
+        for lmp in (lmp_native, lmp_julia)
+            command(lmp, """
+                units $units
+                atom_style charge
+                box tilt large
+                atom_modify map array sort 0 0
+
+                boundary p p p
+                region cell block 0 10.0 0 10.0 0 10.0 units box
+                create_box 1 cell
+
+                create_atoms 1 random 10 1 NULL
+                set type 1 charge 2.0
+                mass 1 1.0
+                compute potential all pe/atom
+                compute virial all stress/atom NULL
+                compute virial_tot all pressure thermo_temp
+            """)
+        end
+
+        cutoff = 2.5
+        command(lmp_native, "pair_style coul/cut $cutoff")
+        command(lmp_native, "pair_coeff * *")
+
+        command(lmp_julia, "pair_style none\nrun 0")
+
+        # Register external fix
+        system_properties = @NamedTuple{qqrd2e::Float64}
+        atom_properties = @NamedTuple{q::Float64}
+        lj = LAMMPS.PairExternal(lmp_julia, "julia_coul", system_properties, atom_properties, cutoff; backend) do r, system, iatom, jatom
+            energy = system.qqrd2e * (iatom.q * jatom.q) / r
+            force = system.qqrd2e * (iatom.q * jatom.q) / r^2
+            return backend === nothing ? (energy, force) : energy
+        end
+
+        # Setup atoms
+        positions = rand(3, 10) .* 5
+        for lmp in (lmp_native, lmp_julia)
+            # command(lmp, """
+            #     create_atoms 1 random $natoms 1 NULL
+            #     set type 1 charge 2.0
+            #     mass 1 1.0
+            #     compute potential all pe/atom
+            #     compute virial all stress/atom NULL
+            #     compute virial_tot all pressure thermo_temp
+            # """)
 
             scatter!(lmp, "x", positions)
 


### PR DESCRIPTION
Many pair styles (like coul/cut) need access to per-atom and and unit information (for some reason unit information is only set after the run command) in order to calculate the potentials. Currently this would only be possible by calling `extract_atom` and `extract_global` inside the `calculate_potential` function. This would be wildly inefficient and also causes problems with enzyme. Therefore I've implemented a system that allows `PairExternal` to pass the neccessary information to `caluclate_potential`.

The following example shows how this works:
```julia
system_properties = @NamedTuple{qqrd2e::Float64}
atom_properties = @NamedTuple{q::Float64}
LAMMPS.PairExternal(lmp_julia, "julia_coul", system_properties, atom_properties, cutoff; backend) do r, system, iatom, jatom
    energy = system.qqrd2e * (iatom.q * jatom.q) / r
    force = system.qqrd2e * (iatom.q * jatom.q) / r^2
    return backend === nothing ? (energy, force) : energy
end
```

Alternatively we could just instruct the user to implement their own `PairExternal` if they want to have access to this information and then keep our own `PairExternal` the way it currently is.

P.S. all of the new functions/structs that I've introduced to make this work are intended to be internal and aren't part of the user facing API.

PP.S. for my own application, I need to have access to a custom per-atom property "d_alpha". This implementation makes this possible as well.